### PR TITLE
Fix websocket scheme detection

### DIFF
--- a/docs/technical/websocket-architecture.md
+++ b/docs/technical/websocket-architecture.md
@@ -50,7 +50,9 @@ export function usePamWebSocketConnection({
 
 1. **Initialization**
    ```typescript
-   const wsUrl = `${backendUrl.replace("https", "wss")}/ws/${userId}?token=${authToken}`;
+   const sanitizedBackendUrl = backendUrl.replace(/\/$/, "");
+   const wsProtocol = sanitizedBackendUrl.startsWith("https") ? "wss" : "ws";
+   const wsUrl = `${sanitizedBackendUrl.replace(/^https?/, wsProtocol)}/ws/${userId}?token=${authToken}`;
    ws.current = new WebSocket(wsUrl);
    ```
 

--- a/src/components/Pam.tsx
+++ b/src/components/Pam.tsx
@@ -99,7 +99,9 @@ const Pam: React.FC<PamProps> = ({ mode = "floating" }) => {
 
     try {
       const backendUrl = import.meta.env.VITE_PAM_BACKEND_URL || "https://pam-backend.onrender.com";
-      const wsUrl = `${backendUrl.replace("https", "wss")}/ws/${user.id}?token=${sessionToken || "demo-token"}`;
+      const sanitizedBackendUrl = backendUrl.replace(/\/$/, "");
+      const wsProtocol = sanitizedBackendUrl.startsWith("https") ? "wss" : "ws";
+      const wsUrl = `${sanitizedBackendUrl.replace(/^https?/, wsProtocol)}/ws/${user.id}?token=${sessionToken || "demo-token"}`;
       
       setConnectionStatus("Connecting");
       wsRef.current = new WebSocket(wsUrl);

--- a/src/hooks/pam/usePamWebSocketConnection.ts
+++ b/src/hooks/pam/usePamWebSocketConnection.ts
@@ -45,7 +45,9 @@ export function usePamWebSocketConnection({ userId, onMessage, onStatusChange }:
 
     try {
       const backendUrl = import.meta.env.VITE_PAM_BACKEND_URL || "https://pam-backend.onrender.com";
-      const wsUrl = `${backendUrl.replace("https", "wss")}/ws/${userId}?token=${localStorage.getItem("auth-token") || "demo-token"}`;
+      // Support both http and https URLs when constructing the WebSocket URL
+      const wsProtocol = backendUrl.startsWith("https") ? "wss" : "ws";
+      const wsUrl = `${backendUrl.replace(/^https?/, wsProtocol)}/ws/${userId}?token=${localStorage.getItem("auth-token") || "demo-token"}`;
       console.log('🔌 Attempting PAM WebSocket connection:', wsUrl);
       
       ws.current = new WebSocket(wsUrl);

--- a/src/hooks/pam/usePamWebSocketConnection.ts
+++ b/src/hooks/pam/usePamWebSocketConnection.ts
@@ -45,9 +45,9 @@ export function usePamWebSocketConnection({ userId, onMessage, onStatusChange }:
 
     try {
       const backendUrl = import.meta.env.VITE_PAM_BACKEND_URL || "https://pam-backend.onrender.com";
-      // Support both http and https URLs when constructing the WebSocket URL
-      const wsProtocol = backendUrl.startsWith("https") ? "wss" : "ws";
-      const wsUrl = `${backendUrl.replace(/^https?/, wsProtocol)}/ws/${userId}?token=${localStorage.getItem("auth-token") || "demo-token"}`;
+      const sanitizedBackendUrl = backendUrl.replace(/\/$/, "");
+      const wsProtocol = sanitizedBackendUrl.startsWith("https") ? "wss" : "ws";
+      const wsUrl = `${sanitizedBackendUrl.replace(/^https?/, wsProtocol)}/ws/${userId}?token=${localStorage.getItem("auth-token") || "demo-token"}`;
       console.log('🔌 Attempting PAM WebSocket connection:', wsUrl);
       
       ws.current = new WebSocket(wsUrl);


### PR DESCRIPTION
## Summary
- handle http backends when creating websocket URL

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: asyncpg)*

------
https://chatgpt.com/codex/tasks/task_e_685e2f5f79048323b7fa1f977e07df57