### PR TITLE
Fix WebSocket protocol detection

### DIFF
--- a/docs/technical/websocket-architecture.md
+++ b/docs/technical/websocket-architecture.md
@@ -50,7 +50,9 @@ export function usePamWebSocketConnection({
 
 1. **Initialization**
    ```typescript
-   const wsUrl = `${backendUrl.replace("https", "wss")}/ws/${userId}?token=${authToken}`;
+   // Support both http and https URLs when constructing the WebSocket URL
+   const wsProtocol = backendUrl.startsWith("https") ? "wss" : "ws";
+   const wsUrl = `${backendUrl.replace(/^https?/, wsProtocol)}/ws/${userId}?token=${authToken}`;
    ws.current = new WebSocket(wsUrl);
    ```
 

--- a/src/components/Pam.tsx
+++ b/src/components/Pam.tsx
@@ -99,7 +99,9 @@ const Pam: React.FC<PamProps> = ({ mode = "floating" }) => {
 
     try {
       const backendUrl = import.meta.env.VITE_PAM_BACKEND_URL || "https://pam-backend.onrender.com";
-      const wsUrl = `${backendUrl.replace("https", "wss")}/ws/${user.id}?token=${sessionToken || "demo-token"}`;
+      // Support both http and https URLs when constructing the WebSocket URL
+      const wsProtocol = backendUrl.startsWith("https") ? "wss" : "ws";
+      const wsUrl = `${backendUrl.replace(/^https?/, wsProtocol)}/ws/${user.id}?token=${sessionToken || "demo-token"}`;
       
       setConnectionStatus("Connecting");
       wsRef.current = new WebSocket(wsUrl);

--- a/src/hooks/pam/usePamWebSocketConnection.ts
+++ b/src/hooks/pam/usePamWebSocketConnection.ts
@@ -45,7 +45,9 @@ export function usePamWebSocketConnection({ userId, onMessage, onStatusChange }:
 
     try {
       const backendUrl = import.meta.env.VITE_PAM_BACKEND_URL || "https://pam-backend.onrender.com";
-      const wsUrl = `${backendUrl.replace("https", "wss")}/ws/${userId}?token=${localStorage.getItem("auth-token") || "demo-token"}`;
+      // Support both http and https URLs when constructing the WebSocket URL
+      const wsProtocol = backendUrl.startsWith("https") ? "wss" : "ws";
+      const wsUrl = `${backendUrl.replace(/^https?/, wsProtocol)}/ws/${userId}?token=${localStorage.getItem("auth-token") || "demo-token"}`;
       console.log('🔌 Attempting PAM WebSocket connection:', wsUrl);
       
       ws.current = new WebSocket(wsUrl);


### PR DESCRIPTION
## Summary
- support http URLs in PAM WebSocket connection code

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'asyncpg')*

------
https://chatgpt.com/codex/tasks/task_e_685e3a4d195483239889b51b858651a1