### PR TITLE
Fix Render startup path

### DIFF
--- a/backend/render.yaml
+++ b/backend/render.yaml
@@ -4,9 +4,8 @@ services:
     env: python
     plan: free
     runtime: python-3.11
-    rootDir: backend
-    buildCommand: pip install -r requirements.txt
-    startCommand: uvicorn app.main:app --host 0.0.0.0 --port $PORT
+    buildCommand: cd backend && pip install -r requirements.txt
+    startCommand: cd backend && uvicorn app.main:app --host 0.0.0.0 --port $PORT
     envVars:
       - key: ENVIRONMENT
         value: production
@@ -33,9 +32,8 @@ services:
     name: pam-celery-worker
     env: python
     runtime: python-3.11
-    rootDir: backend
-    buildCommand: pip install -r requirements.txt
-    startCommand: celery -A app.workers.celery worker --loglevel=info
+    buildCommand: cd backend && pip install -r requirements.txt
+    startCommand: cd backend && celery -A app.workers.celery worker --loglevel=info
     envVars:
       - key: ENVIRONMENT
         value: production
@@ -57,9 +55,8 @@ services:
     name: pam-celery-beat
     env: python
     runtime: python-3.11
-    rootDir: backend
-    buildCommand: pip install -r requirements.txt
-    startCommand: celery -A app.workers.celery beat --loglevel=info
+    buildCommand: cd backend && pip install -r requirements.txt
+    startCommand: cd backend && celery -A app.workers.celery beat --loglevel=info
     envVars:
       - key: ENVIRONMENT
         value: production

--- a/docs/guides/troubleshooting/deployment-issues.md
+++ b/docs/guides/troubleshooting/deployment-issues.md
@@ -61,6 +61,31 @@ git commit -m "Force rebuild"
 git push origin main
 ```
 
+### ModuleNotFoundError: No module named `app`
+
+#### Symptom
+```
+ModuleNotFoundError: No module named 'app'
+```
+
+This happens when Render runs the start command from the repository root, so
+Python cannot locate the `backend/app` package.
+
+#### Fix
+Update `startCommand` in `render.yaml` to change into the backend directory:
+
+```yaml
+startCommand: cd backend && uvicorn app.main:app --host 0.0.0.0 --port $PORT
+```
+
+Similarly update `buildCommand`:
+
+```yaml
+buildCommand: cd backend && pip install -r requirements.txt
+```
+
+Re-deploy after committing these changes.
+
 ### Service Not Responding
 
 #### Verification Steps

--- a/render.yaml
+++ b/render.yaml
@@ -6,9 +6,8 @@ services:
     env: python
     plan: free
     runtime: python-3.11
-    rootDir: backend
-    buildCommand: pip install -r requirements.txt
-    startCommand: uvicorn app.main:app --host 0.0.0.0 --port $PORT
+    buildCommand: cd backend && pip install -r requirements.txt
+    startCommand: cd backend && uvicorn app.main:app --host 0.0.0.0 --port $PORT
     envVars:
       - key: ENVIRONMENT
         value: production


### PR DESCRIPTION
## Summary
- run backend build and start commands from the backend directory so `app` is discoverable
- document ModuleNotFoundError solution in deployment troubleshooting guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'asyncpg' and 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685e63cc05748323b996acfe67ec6a18