### PR TITLE
Add get_settings helper in config

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -68,5 +68,10 @@ class Settings(BaseSettings):
         "extra": "allow"
     }
 
+
 # Global settings instance
 settings = Settings()
+
+def get_settings() -> Settings:
+    """Retrieve the global settings."""
+    return settings


### PR DESCRIPTION
## Summary
- add a `get_settings` helper to `app/core/config.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*
- `python3 -c "from app.services.database import get_database_service; print('✅ Database connected')"` *(fails: ModuleNotFoundError: No module named 'supabase')*

------
https://chatgpt.com/codex/tasks/task_e_685f7b548fb48323b483ca11ea21ab4b