### PR TITLE
Connect frontend to backend API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ __pycache__/
 *.pyd
 venv/
 .env
+!src/.env
 
 # Node
 node_modules/

--- a/src/.env
+++ b/src/.env
@@ -1,0 +1,1 @@
+VITE_BACKEND_URL=http://localhost:8000

--- a/src/components/MicButton.tsx
+++ b/src/components/MicButton.tsx
@@ -1,6 +1,7 @@
 
 // src/components/MicButton.tsx
 import React, { useState, useRef } from 'react';
+import { apiFetch } from '@/services/api';
 
 interface MicButtonProps {
   inline?: boolean;
@@ -28,7 +29,7 @@ export default function MicButton({ inline = false, disabled = false }: MicButto
       recorder.onstop = async () => {
         const blob = new Blob(chunksRef.current, { type: 'audio/webm' });
         try {
-          await fetch(import.meta.env.VITE_N8N_VOICE_WEBHOOK_URL, {
+          await apiFetch('/api/v1/pam/voice', {
             method: 'POST',
             body: blob,
           });

--- a/src/components/Pam.tsx
+++ b/src/components/Pam.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect, useCallback } from "react";
 import { X, Send, Mic, MicOff, MapPin, Calendar, DollarSign } from "lucide-react";
 import { useAuth } from "@/context/AuthContext";
 import { pamUIController } from "@/lib/PamUIController";
+import { getWebSocketUrl } from "@/services/api";
 
 interface PamMessage {
   id: string;
@@ -98,8 +99,7 @@ const Pam: React.FC<PamProps> = ({ mode = "floating" }) => {
     if (!user?.id) return;
 
     try {
-      const backendUrl = import.meta.env.VITE_PAM_BACKEND_URL || "https://pam-backend.onrender.com";
-      const wsUrl = `${backendUrl.replace("https", "wss")}/ws/${user.id}?token=${sessionToken || "demo-token"}`;
+      const wsUrl = `${getWebSocketUrl('/api/v1/pam/ws')}/${user.id}?token=${sessionToken || "demo-token"}`;
       
       setConnectionStatus("Connecting");
       wsRef.current = new WebSocket(wsUrl);

--- a/src/components/PricingPlans.tsx
+++ b/src/components/PricingPlans.tsx
@@ -4,8 +4,8 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { Button } from "@/components/ui/button";
 import { CheckCircle, Loader2 } from "lucide-react";
 import { useAuth } from "@/context/AuthContext";
-import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
+import { apiFetch } from "@/services/api";
 import { useNavigate } from "react-router-dom";
 
 const PricingPlans = () => {
@@ -23,17 +23,19 @@ const PricingPlans = () => {
     setIsLoading(priceId);
     
     try {
-      const { data, error } = await supabase.functions.invoke('create-checkout', {
-        body: {
+      const response = await apiFetch('/api/v1/subscription/create-checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
           priceId,
           successUrl: `${window.location.origin}/payment-success`,
           cancelUrl: `${window.location.origin}/payment-canceled`,
-        }
+        })
       });
 
-      if (error) throw error;
+      if (!response.ok) throw new Error('Request failed');
 
-      // Redirect to Stripe Checkout
+      const data = await response.json();
       window.location.href = data.url;
     } catch (error) {
       console.error("Error creating checkout session:", error);

--- a/src/components/pam/PamAssistant.tsx
+++ b/src/components/pam/PamAssistant.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { useToast } from '@/hooks/use-toast';
-import { supabase } from '@/integrations/supabase/client';
+import { apiFetch } from '@/services/api';
 
 interface Alert {
   id: string;
@@ -85,13 +85,14 @@ export const PamAssistant: React.FC<PamAssistantProps> = ({ onAlertAction }) => 
     try {
       setIsLoading(true);
       
-      // Call the proactive monitor function
-      const { data, error } = await supabase.functions.invoke('proactive-monitor');
-      
-      if (error) {
-        console.error('Error fetching proactive alerts:', error);
+      const response = await apiFetch('/api/v1/pam/proactive-monitor');
+
+      if (!response.ok) {
+        console.error('Error fetching proactive alerts');
         return;
       }
+
+      const data = await response.json();
 
       // Mock alerts for demonstration since the function returns processing stats
       const mockAlerts: Alert[] = [

--- a/src/components/subscription/PricingPlansUpdated.tsx
+++ b/src/components/subscription/PricingPlansUpdated.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { Button } from "@/components/ui/button";
 import { CheckCircle, Loader2 } from "lucide-react";
 import { useAuth } from "@/context/AuthContext";
-import { supabase } from "@/integrations/supabase/client";
+import { apiFetch } from "@/services/api";
 import { toast } from "sonner";
 import { useNavigate } from "react-router-dom";
 
@@ -23,17 +23,19 @@ const PricingPlansUpdated = () => {
     setIsLoading(priceId);
     
     try {
-      const { data, error } = await supabase.functions.invoke('create-checkout', {
-        body: {
+      const response = await apiFetch('/api/v1/subscription/create-checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
           priceId,
           successUrl: `${window.location.origin}/payment-success`,
           cancelUrl: `${window.location.origin}/payment-canceled`,
-        }
+        })
       });
 
-      if (error) throw error;
+      if (!response.ok) throw new Error('Request failed');
 
-      // Redirect to Stripe Checkout
+      const data = await response.json();
       window.location.href = data.url;
     } catch (error) {
       console.error("Error creating checkout session:", error);

--- a/src/components/wheels/trip-planner/PAMContext.tsx
+++ b/src/components/wheels/trip-planner/PAMContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
+import { apiFetch } from '@/services/api';
 import { Friend } from '../trip-planner/hooks/useSocialTripState';
 import { Suggestion } from '../trip-planner/types';
 
@@ -126,8 +127,7 @@ export function PAMProvider({ children, initialTrip }: PAMProviderProps) {
     addMessage({ role: 'user', content });
 
     try {
-      // Call Supabase Edge Function for PAM response
-      const response = await fetch('/functions/v1/pam-trip-chat', {
+      const response = await apiFetch('/api/v1/pam/trip-chat', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/components/wheels/trip-planner/TripService.tsx
+++ b/src/components/wheels/trip-planner/TripService.tsx
@@ -1,13 +1,13 @@
 
-import { supabase } from "@/integrations/supabase/client";
 import { TripPayload, Waypoint, Suggestion } from "./types";
+import { apiFetch } from "@/services/api";
 
 export class TripService {
-  private static TRIP_WEBHOOK_URL = import.meta.env.VITE_N8N_TRIP_WEBHOOK;
+  private static TRIP_API_URL = "/api/v1/trips";
 
   static async submitTripPlan(payload: TripPayload): Promise<void> {
     try {
-      await fetch(this.TRIP_WEBHOOK_URL, {
+      await apiFetch(TripService.TRIP_API_URL, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
@@ -33,7 +33,7 @@ export class TripService {
         mode,
       };
       
-      const res = await fetch(this.TRIP_WEBHOOK_URL, {
+      const res = await apiFetch(TripService.TRIP_API_URL, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),

--- a/src/hooks/pam/usePamWebSocketConnection.ts
+++ b/src/hooks/pam/usePamWebSocketConnection.ts
@@ -1,4 +1,5 @@
 import { useRef, useState, useCallback, useEffect } from 'react';
+import { getWebSocketUrl } from '@/services/api';
 
 interface WebSocketConnectionConfig {
   userId: string;
@@ -44,8 +45,7 @@ export function usePamWebSocketConnection({ userId, onMessage, onStatusChange }:
     }
 
     try {
-      const backendUrl = import.meta.env.VITE_PAM_BACKEND_URL || "https://pam-backend.onrender.com";
-      const wsUrl = `${backendUrl.replace("https", "wss")}/ws/${userId}?token=${localStorage.getItem("auth-token") || "demo-token"}`;
+      const wsUrl = `${getWebSocketUrl('/api/v1/pam/ws')}/${userId}?token=${localStorage.getItem("auth-token") || "demo-token"}`;
       console.log('🔌 Attempting PAM WebSocket connection:', wsUrl);
       
       ws.current = new WebSocket(wsUrl);

--- a/src/hooks/useEnhancedPamMemory.ts
+++ b/src/hooks/useEnhancedPamMemory.ts
@@ -1,6 +1,7 @@
 
 import { supabase } from '@/integrations/supabase/client';
 import type { EnhancedPamMemory, KnowledgeSearchResult } from '@/types/knowledgeTypes';
+import { apiFetch } from '@/services/api';
 
 // Helper function to get enhanced PAM memory including personal knowledge
 export const getEnhancedPamMemory = async (userId: string, region: string, currentContext?: string): Promise<EnhancedPamMemory> => {
@@ -65,13 +66,13 @@ export const getEnhancedPamMemory = async (userId: string, region: string, curre
       try {
         console.log('🔍 Searching personal knowledge for context:', currentContext);
         
-        const { data: searchResults, error } = await supabase.functions.invoke('search-user-knowledge', {
-          body: {
-            userId,
-            query: currentContext,
-            limit: 3
-          }
+        const response = await apiFetch('/api/v1/knowledge/search', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ userId, query: currentContext, limit: 3 })
         });
+        const searchResults = response.ok ? await response.json() : null;
+        const error = response.ok ? null : new Error('Request failed');
 
         if (error) {
           console.error('❌ Knowledge search error:', error);

--- a/src/hooks/usePam.ts
+++ b/src/hooks/usePam.ts
@@ -8,8 +8,6 @@ import { useOffline } from "@/context/OfflineContext";
 // Use usePamWebSocket for real-time WebSocket communication instead
 // This hook is kept for backward compatibility only
 
-const DEPRECATED_WEBHOOK_URL = "https://treflip2025.app.n8n.cloud/webhook/pam-chat";
-
 export function usePam() {
   const { user } = useAuth();
   const { isOffline } = useOffline();

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/context/AuthContext';
+import { apiFetch } from '@/services/api';
 
 interface Profile {
   id: number;
@@ -42,7 +43,7 @@ export const useProfile = () => {
 
       try {
         // Call your backend API instead of direct Supabase
-        const response = await fetch(`https://pam-backend.onrender.com/api/v1/users/${user.id}/profile`);
+        const response = await apiFetch(`/api/v1/users/${user.id}/profile`);
         
         if (!response.ok) {
           throw new Error('Failed to fetch profile');
@@ -68,7 +69,7 @@ export const useProfile = () => {
     
     setLoading(true);
     try {
-      const response = await fetch(`https://pam-backend.onrender.com/api/v1/users/${user.id}/profile`);
+      const response = await apiFetch(`/api/v1/users/${user.id}/profile`);
       
       if (!response.ok) {
         throw new Error('Failed to refresh profile');

--- a/src/hooks/useUserKnowledge.ts
+++ b/src/hooks/useUserKnowledge.ts
@@ -1,6 +1,7 @@
 
 import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
+import { apiFetch } from '@/services/api';
 import { useAuth } from '@/context/AuthContext';
 import { toast } from 'sonner';
 import type { UserKnowledgeBucket, UserKnowledgeDocument } from '@/types/knowledgeTypes';
@@ -190,11 +191,13 @@ export const useUserKnowledge = () => {
   // Process document (extract text and create chunks)
   const processDocument = async (documentId: string) => {
     try {
-      const { error } = await supabase.functions.invoke('process-user-document', {
-        body: { documentId }
+      const response = await apiFetch('/api/v1/knowledge/process', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ documentId })
       });
 
-      if (error) throw error;
+      if (!response.ok) throw new Error('Request failed');
     } catch (error) {
       console.error('Error processing document:', error);
       toast.error('Failed to process document');

--- a/src/lib/PamUIController.ts
+++ b/src/lib/PamUIController.ts
@@ -1,4 +1,5 @@
 import { toast } from "@/hooks/use-toast";
+import { getWebSocketUrl } from "@/services/api";
 
 interface NavigationParams {
   [key: string]: string | number;
@@ -158,8 +159,7 @@ class PamUIController {
    */
   private connectWebSocket(): void {
     try {
-      // Connect to Supabase edge function WebSocket endpoint
-      const wsUrl = `wss://pam-backend.onrender.com/api/v1/pam/ws`;
+      const wsUrl = getWebSocketUrl('/api/v1/pam/ws');
       
       this.websocket = new WebSocket(wsUrl);
 

--- a/src/lib/voiceService.ts
+++ b/src/lib/voiceService.ts
@@ -1,4 +1,5 @@
 
+import { apiFetch } from '@/services/api';
 export interface VoiceSettings {
   enabled: boolean;
   autoPlay: boolean;
@@ -47,12 +48,10 @@ class PamVoiceService {
     const formattedText = this.formatTextForTTS(options.text, options.emotion, options.context);
 
     try {
-      // Call our Supabase Edge Function
-      const response = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/nari-dia-tts`, {
+      const response = await apiFetch('/api/v1/pam/voice', {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`
+          'Content-Type': 'application/json'
         },
         body: JSON.stringify({
           text: formattedText,

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -9,8 +9,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
-
-const WEBHOOK_URL = 'https://treflip2025.app.n8n.cloud/webhook/79d30fcb-ac7a-4a1d-9a53-9532bde02e52';
+import { apiFetch } from '@/services/api';
 
 const Onboarding: React.FC = () => {
   const { user, isAuthenticated } = useAuth();
@@ -88,9 +87,9 @@ const Onboarding: React.FC = () => {
         ...formData,
       };
 
-      console.log('🚀 Submitting onboarding data to Pam webhook:', payload);
+      console.log('🚀 Submitting onboarding data:', payload);
 
-      const response = await fetch(WEBHOOK_URL, {
+      const response = await apiFetch('/api/v1/onboarding', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,0 +1,10 @@
+export const API_BASE_URL = import.meta.env.VITE_BACKEND_URL || '';
+
+export function apiFetch(path: string, options: RequestInit = {}) {
+  const url = `${API_BASE_URL}${path}`;
+  return fetch(url, options);
+}
+
+export function getWebSocketUrl(path: string) {
+  return (API_BASE_URL || '').replace(/^http/, 'ws') + path;
+}


### PR DESCRIPTION
## Summary
- add centralized API helper
- update Onboarding form and other components to use new API
- remove N8N and Supabase function calls
- configure WebSocket URLs via backend URL
- track frontend `.env`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q` *(fails: ModuleNotFoundError for openai and httpx)*

------
https://chatgpt.com/codex/tasks/task_e_685f8323b0488323a9a3498aea7ad59a