### PR TITLE
Connect PAM WebSocket to backend

### DIFF
--- a/src/hooks/usePamWebSocket.ts
+++ b/src/hooks/usePamWebSocket.ts
@@ -1,5 +1,5 @@
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 interface WebSocketMessage {
   type: string;
@@ -9,20 +9,56 @@ interface WebSocketMessage {
 export const usePamWebSocket = () => {
   const [isConnected, setIsConnected] = useState(false);
   const [messages, setMessages] = useState<WebSocketMessage[]>([]);
+  const wsRef = useRef<WebSocket | null>(null);
+
+  // WebSocket endpoint for the PAM backend
+  const wsUrl = `ws://localhost:8000/api/v1/pam/ws`;
 
   const sendMessage = (message: any) => {
-    // Mock WebSocket message sending
-    console.log('Sending message:', message);
-    return true;
+    if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify(message));
+      return true;
+    }
+    return false;
   };
 
   const connect = () => {
-    setIsConnected(true);
+    if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) return;
+
+    try {
+      wsRef.current = new WebSocket(wsUrl);
+
+      wsRef.current.onopen = () => {
+        setIsConnected(true);
+      };
+
+      wsRef.current.onmessage = (event) => {
+        try {
+          const message = JSON.parse(event.data);
+          setMessages((prev) => [...prev, message]);
+        } catch (error) {
+          console.error('Failed to parse PAM message:', error);
+        }
+      };
+
+      wsRef.current.onclose = () => {
+        setIsConnected(false);
+      };
+
+      wsRef.current.onerror = () => {
+        setIsConnected(false);
+      };
+    } catch (error) {
+      console.error('Failed to connect to PAM WebSocket:', error);
+      setIsConnected(false);
+    }
   };
 
   useEffect(() => {
-    // Mock connection
-    setTimeout(() => setIsConnected(true), 1000);
+    connect();
+    return () => {
+      wsRef.current?.close();
+    };
   }, []);
 
   return {


### PR DESCRIPTION
## Summary
- integrate real WebSocket in `usePamWebSocket`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685f866063108323958f6cc6ab3ba7d6