### PR TITLE
Fix env variables and websocket url

### DIFF
--- a/docs/technical/api-documentation.md
+++ b/docs/technical/api-documentation.md
@@ -37,7 +37,7 @@ Authenticate user and receive JWT token.
 **Response**:
 ```json
 {
-  "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "access_token": "<token>",
   "token_type": "bearer",
   "expires_in": 1800,
   "user": {

--- a/docs/technical/websocket-architecture.md
+++ b/docs/technical/websocket-architecture.md
@@ -331,7 +331,7 @@ VITE_PAM_BACKEND_URL=https://pam-backend.onrender.com
 ```bash
 OPENAI_API_KEY=sk-...
 SUPABASE_URL=https://...supabase.co
-SUPABASE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+SUPABASE_KEY=<token>
 JWT_SECRET=your-jwt-secret
 ENVIRONMENT=production
 ```

--- a/src/components/Pam.tsx
+++ b/src/components/Pam.tsx
@@ -100,7 +100,7 @@ const Pam: React.FC<PamProps> = ({ mode = "floating" }) => {
     if (!user?.id) return;
 
     try {
-      const wsUrl = `${getWebSocketUrl('/api/v1/pam/ws')}/${user.id}?token=${sessionToken || "demo-token"}`;
+      const wsUrl = `${getWebSocketUrl('/api/v1/pam/ws')}?token=${sessionToken || 'demo-token'}`;
       
       setConnectionStatus("Connecting");
       wsRef.current = new WebSocket(wsUrl);

--- a/src/hooks/usePamWebSocket.ts
+++ b/src/hooks/usePamWebSocket.ts
@@ -1,5 +1,6 @@
 
 import { useState, useEffect, useRef } from 'react';
+import { getWebSocketUrl } from '@/services/api';
 
 interface WebSocketMessage {
   type: string;
@@ -11,8 +12,8 @@ export const usePamWebSocket = () => {
   const [messages, setMessages] = useState<WebSocketMessage[]>([]);
   const wsRef = useRef<WebSocket | null>(null);
 
-  // WebSocket endpoint for the PAM backend
-  const wsUrl = `ws://localhost:8000/api/v1/pam/ws`;
+  // WebSocket endpoint for the PAM backend using configured backend URL
+  const wsUrl = getWebSocketUrl('/api/v1/pam/ws');
 
   const sendMessage = (message: any) => {
     if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -1,8 +1,12 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL!;
-const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY!;
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL || '';
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY || '';
+
+if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+  console.error('Supabase environment variables are missing');
+}
 
 // Create the supabase client
 export const supabase = createClient<Database>(

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,4 +1,4 @@
-project_id = "kycoklimpzkyrecbjecn"
+project_id = "${SUPABASE_PROJECT_ID}"
 
 [api]
 enabled = true

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,8 @@
 
 import type { Config } from "tailwindcss";
 
+const supabaseUrl = process.env.VITE_SUPABASE_URL || "";
+
 export default {
 	darkMode: ["class"],
 	content: [
@@ -102,8 +104,8 @@ export default {
 				'pulse-slow': 'pulse-slow 3s ease-in-out infinite',
 			},
             backgroundImage: {
-                'hero-pattern': "url('https://kycoklimpzkyrecbjecn.supabase.co/storage/v1/object/public/public-assets//WheelsnadwinsHero.jpg')",
-                'logo': "url('https://kycoklimpzkyrecbjecn.supabase.co/storage/v1/object/public/public-assets//wheels%20and%20wins%20Logo%20alpha.png')",
+                'hero-pattern': `url('${supabaseUrl}/storage/v1/object/public/public-assets//WheelsnadwinsHero.jpg')`,
+                'logo': `url('${supabaseUrl}/storage/v1/object/public/public-assets//wheels%20and%20wins%20Logo%20alpha.png')`,
             },
 		}
 	},


### PR DESCRIPTION
## Summary
- use backend URL for PAM websocket hook
- drop user id from Pam.tsx websocket
- validate Supabase env vars instead of using hardcoded values
- reference supabase project id by env var in config
- fetch hero images from env-defined Supabase storage
- scrub docs of leaked tokens

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f9f0fe5508323a13d776eeddc1945