### PR TITLE
Fix imports and namespace packaging

### DIFF
--- a/aioredis.py
+++ b/aioredis.py
@@ -1,0 +1,3 @@
+from redis.asyncio import Redis, ConnectionPool, from_url, StrictRedis
+
+__all__ = ['Redis', 'ConnectionPool', 'from_url', 'StrictRedis']

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,2 +1,7 @@
 
-# Empty file to make app a package
+"""Namespace package for shared application modules."""
+
+from pkgutil import extend_path
+
+__path__ = extend_path(__path__, __name__)
+

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,1 +1,6 @@
+"""Namespace package for backend application modules."""
+
+from pkgutil import extend_path
+
+__path__ = extend_path(__path__, __name__)
 

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -10,8 +10,8 @@ import structlog
 from structlog.typing import FilteringBoundLogger
 import sentry_sdk
 from sentry_sdk.integrations.logging import LoggingIntegration
-from sentry_sdk.integrations.sqlalchemy import SqlAlchemyIntegration
-from pydantic import BaseSettings
+from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
+from pydantic_settings import BaseSettings
 
 # Context variable for request correlation
 request_id_var: ContextVar[Optional[str]] = ContextVar('request_id', default=None)
@@ -65,7 +65,7 @@ def setup_sentry() -> None:
         traces_sample_rate=settings.SENTRY_TRACES_SAMPLE_RATE,
         integrations=[
             sentry_logging,
-            SqlAlchemyIntegration(),
+            SqlalchemyIntegration(),
         ],
         attach_stacktrace=True,
         send_default_pii=False,

--- a/backend/app/services/cache.py
+++ b/backend/app/services/cache.py
@@ -3,9 +3,11 @@
 Cache Service
 """
 
+# Re-export CacheService and underlying aioredis for mocking
 from app.services.cache_service import cache_service
+import aioredis
 
-# Re-export for backward compatibility
+# Re-exports for backward compatibility
 CacheService = cache_service.__class__
 
 __all__ = ['cache_service', 'CacheService']

--- a/backend/app/services/database.py
+++ b/backend/app/services/database.py
@@ -13,7 +13,10 @@ class DatabaseService:
     
     def __init__(self):
         self.client: Optional[Client] = None
-        self._initialize_client()
+        try:
+            self._initialize_client()
+        except Exception as e:
+            logger.warning(f"Database initialization skipped: {e}")
     
     def _initialize_client(self):
         """Initialize Supabase client with error handling"""
@@ -50,9 +53,12 @@ class DatabaseService:
             self._initialize_client()
         return self.client
 
-# Global instance
-database_service = DatabaseService()
+# Global instance, initialized lazily
+database_service: Optional[DatabaseService] = None
 
 def get_database_service() -> DatabaseService:
-    """Get database service instance"""
+    """Get or create the global database service instance."""
+    global database_service
+    if not database_service:
+        database_service = DatabaseService()
     return database_service

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,1 +1,5 @@
+import pytest
+
+# Enable support for async tests
+pytest_plugins = ("pytest_asyncio",)
 


### PR DESCRIPTION
## Summary
- make `app` a namespace package so backend modules resolve
- update Sentry integration name
- avoid failing database init when config values are missing
- expose `aioredis` for easier mocking
- enable `pytest_asyncio` plugin for tests

## Testing
- `pytest backend/tests/unit -q` *(fails: Database initialization skipped and async plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_685fa1ea982c83238288fee171de56d6