### PR TITLE
Connect SocialSidebar to meetup planner

### DIFF
--- a/src/components/wheels/TripPlannerApp.tsx
+++ b/src/components/wheels/TripPlannerApp.tsx
@@ -494,10 +494,17 @@ export default function TripPlannerApp() {
                         <X className="w-4 h-4" />
                       </Button>
                     </div>
-                    <SocialSidebar 
+                    <SocialSidebar
                       friends={integratedState.social.friends}
                       groupTrips={integratedState.social.groupTrips}
-                      onCreateGroupTrip={() => console.log('Create group trip')}
+                      onOpenMeetupPlanner={() => {
+                        if (integratedState.ui.showSocialSidebar) {
+                          integratedState.toggleFeature('social');
+                        }
+                        if (!integratedState.ui.showMeetupPlanner) {
+                          integratedState.toggleFeature('meetup');
+                        }
+                      }}
                       isOpen={true}
                       onClose={() => integratedState.toggleFeature('social')}
                       calendarEvents={[]}

--- a/src/components/wheels/trip-planner/SocialSidebar.tsx
+++ b/src/components/wheels/trip-planner/SocialSidebar.tsx
@@ -20,7 +20,7 @@ interface SocialSidebarProps {
   calendarEvents: CalendarEvent[];
   groupTrips: GroupTrip[];
   onMessageFriend?: (friend: Friend) => void;
-  onCreateGroupTrip?: () => void;
+  onOpenMeetupPlanner: () => void;
   onAddFriend?: () => void;
 }
 
@@ -31,7 +31,7 @@ export default function SocialSidebar({
   calendarEvents,
   groupTrips,
   onMessageFriend,
-  onCreateGroupTrip,
+  onOpenMeetupPlanner,
   onAddFriend
 }: SocialSidebarProps) {
   if (!isOpen) return null;
@@ -195,6 +195,19 @@ export default function SocialSidebar({
             </div>
           )}
         </div>
+      </div>
+
+      {/* Actions */}
+      <div className="p-4 border-t">
+        <Button
+          className="w-full"
+          onClick={() => {
+            onClose();
+            onOpenMeetupPlanner();
+          }}
+        >
+          Create Trip
+        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add `onOpenMeetupPlanner` prop to `SocialSidebar`
- add Create Trip button that opens the meetup planner
- wire SocialSidebar in TripPlannerApp to toggle meetup planner modal

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6860d64ad6708323880b033434395a91