### PR TITLE
Use env-based Mapbox token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Example environment configuration
+# Copy this file to .env and fill in your own values
+
+# Mapbox public access token (should start with 'pk.')
+VITE_MAPBOX_TOKEN=pk.your_mapbox_token_here
+
+# Other environment variables can go here

--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,5 @@ node_modules/
 .env
 
 .env*
+!.env.example
 

--- a/src/.env
+++ b/src/.env
@@ -1,2 +1,2 @@
 VITE_BACKEND_URL=https://pam-backend.onrender.com
-VITE_MAPBOX_TOKEN=pk.eyJ1IjoibG92YWJsZSIsImEiOiJjbTRmb3M5NjMwYWVlMnFxdjJ4cWh6YjE5In0.c8pPQy_8HhKbO6_hJ2C9zw
+VITE_MAPBOX_TOKEN=pk.your_mapbox_token_here

--- a/src/components/wheels/TripPlanner.tsx
+++ b/src/components/wheels/TripPlanner.tsx
@@ -4,6 +4,7 @@ import { useRegion } from "@/context/RegionContext";
 import { useOffline } from "@/context/OfflineContext";
 import mapboxgl from "mapbox-gl";
 import MapboxDirections from "@mapbox/mapbox-gl-directions/dist/mapbox-gl-directions";
+import { getMapboxToken } from "@/utils/mapboxToken";
 import MapControls from "./trip-planner/MapControls";
 import GeocodeSearch from "./trip-planner/GeocodeSearch";
 import WaypointsList from "./trip-planner/WaypointsList";
@@ -21,7 +22,8 @@ import { Button } from "@/components/ui/button";
 import { Cloud, DollarSign } from "lucide-react";
 
 // Initialize Mapbox token
-mapboxgl.accessToken = import.meta.env.VITE_MAPBOX_TOKEN || '';
+const mapboxToken = getMapboxToken();
+mapboxgl.accessToken = mapboxToken || '';
 
 export default function TripPlanner() {
   const { region } = useRegion();
@@ -84,7 +86,7 @@ export default function TripPlanner() {
     }
   };
 
-  if (!mapboxgl.accessToken) {
+  if (!mapboxToken) {
     return (
       <div className="p-6 bg-yellow-50 border border-yellow-200 rounded-lg">
         <h3 className="font-semibold text-yellow-800">Mapbox Configuration Required</h3>

--- a/src/components/wheels/trip-planner/GeocodeSearch.tsx
+++ b/src/components/wheels/trip-planner/GeocodeSearch.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef } from "react";
 import mapboxgl from "mapbox-gl";
 import MapboxGeocoder from "@mapbox/mapbox-gl-geocoder";
 import MapboxDirections from "@mapbox/mapbox-gl-directions/dist/mapbox-gl-directions";
+import { getMapboxToken } from "@/utils/mapboxToken";
 
 interface GeocodeSearchProps {
   directionsControl: React.MutableRefObject<MapboxDirections | undefined>;
@@ -16,7 +17,7 @@ export default function GeocodeSearch({ directionsControl, disabled = false }: G
     if (!geocoderContainer.current || !directionsControl.current || disabled) return;
 
     const geocoder = new MapboxGeocoder({
-      accessToken: mapboxgl.accessToken,
+      accessToken: getMapboxToken() || '',
       mapboxgl,
       placeholder: disabled ? "Search disabled in offline mode" : "Search for places to add to your route",
       marker: false,

--- a/src/components/wheels/trip-planner/IntegratedTripPlanner.tsx
+++ b/src/components/wheels/trip-planner/IntegratedTripPlanner.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import mapboxgl from "mapbox-gl";
 import MapboxDirections from "@mapbox/mapbox-gl-directions/dist/mapbox-gl-directions";
+import { getMapboxToken } from "@/utils/mapboxToken";
 import TripPlannerControls from "./TripPlannerControls";
 import TripPlannerHeader from "./TripPlannerHeader";
 import OfflineTripBanner from "./OfflineTripBanner";
@@ -75,11 +76,10 @@ export default function IntegratedTripPlanner({ isOffline = false }: IntegratedT
 
   const initializeOnlineMap = () => {
     try {
-      // Set Mapbox access token from environment variable
-      const mapboxToken = import.meta.env.VITE_MAPBOX_TOKEN;
-      
+      const mapboxToken = getMapboxToken();
+
       if (!mapboxToken) {
-        console.error('Mapbox token not found in environment variables');
+        console.error('Mapbox token missing or invalid');
         setMapError('Mapbox token missing. Switching to offline mode...');
         setTimeout(() => initializeOfflineMap(), 1000);
         return;
@@ -214,16 +214,20 @@ export default function IntegratedTripPlanner({ isOffline = false }: IntegratedT
 
   const initializeDirections = () => {
     try {
-      const mapboxToken = import.meta.env.VITE_MAPBOX_TOKEN;
-      
+      const mapboxToken = getMapboxToken();
+      if (!mapboxToken) {
+        console.error('Mapbox token missing. Directions disabled.');
+        return;
+      }
+
       directionsControl.current = new MapboxDirections({
         accessToken: mapboxToken,
         unit: "imperial",
         profile: "mapbox/driving",
         interactive: true,
-        controls: { 
-          instructions: false, 
-          profileSwitcher: false 
+        controls: {
+          instructions: false,
+          profileSwitcher: false
         },
       });
 

--- a/src/components/wheels/trip-planner/MapControls.tsx
+++ b/src/components/wheels/trip-planner/MapControls.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useRef, useState } from "react";
 import mapboxgl from "mapbox-gl";
 import MapboxDirections from "@mapbox/mapbox-gl-directions/dist/mapbox-gl-directions";
+import { getMapboxToken } from "@/utils/mapboxToken";
 import { regionCenters } from "./constants";
 import { reverseGeocode } from "./utils";
 import { Waypoint } from "./types";
@@ -63,8 +64,11 @@ export default function MapControls({
     const center = regionCenters[region] || regionCenters.US;
 
     if (!map.current) {
-      console.log('Initializing map with token:', import.meta.env.VITE_MAPBOX_TOKEN ? 'Token present' : 'Token missing');
-      
+      const mapboxToken = getMapboxToken();
+      console.log('Initializing map with token:', mapboxToken ? 'Token present' : 'Token missing');
+
+      mapboxgl.accessToken = mapboxToken || '';
+
       map.current = new mapboxgl.Map({
         container: mapContainer.current,
         style: "mapbox://styles/mapbox/streets-v11",
@@ -80,8 +84,9 @@ export default function MapControls({
           console.log('Creating directions control after map load');
           
           // Create directions control
+          const token = getMapboxToken();
           const dir = new MapboxDirections({
-            accessToken: mapboxgl.accessToken,
+            accessToken: token || '',
             unit: "metric",
             profile: `mapbox/${travelMode === 'traffic' ? 'driving-traffic' : travelMode}`,
             interactive: !isOffline,

--- a/src/components/wheels/trip-planner/RouteInputs.tsx
+++ b/src/components/wheels/trip-planner/RouteInputs.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef } from "react";
 import mapboxgl from "mapbox-gl";
 import MapboxGeocoder from "@mapbox/mapbox-gl-geocoder";
 import MapboxDirections from "@mapbox/mapbox-gl-directions/dist/mapbox-gl-directions";
+import { getMapboxToken } from "@/utils/mapboxToken";
 import { Lock } from "lucide-react";
 
 interface RouteInputsProps {
@@ -36,7 +37,7 @@ export default function RouteInputs({
 
     // Create origin geocoder only if not locked
     const originGeocoder = new MapboxGeocoder({
-      accessToken: mapboxgl.accessToken,
+      accessToken: getMapboxToken() || '',
       mapboxgl,
       placeholder: "Choose starting point",
       marker: false,
@@ -73,7 +74,7 @@ export default function RouteInputs({
 
     // Create destination geocoder only if not locked
     const destGeocoder = new MapboxGeocoder({
-      accessToken: mapboxgl.accessToken,
+      accessToken: getMapboxToken() || '',
       mapboxgl,
       placeholder: "Choose destination",
       marker: false,

--- a/src/components/wheels/trip-planner/utils.ts
+++ b/src/components/wheels/trip-planner/utils.ts
@@ -1,9 +1,11 @@
 
 import mapboxgl from "mapbox-gl";
+import { getMapboxToken } from "@/utils/mapboxToken";
 
 export async function reverseGeocode([lng, lat]: [number, number]): Promise<string> {
+  const token = getMapboxToken();
   const res = await fetch(
-    `https://api.mapbox.com/geocoding/v5/mapbox.places/${lng},${lat}.json?access_token=${mapboxgl.accessToken}`
+    `https://api.mapbox.com/geocoding/v5/mapbox.places/${lng},${lat}.json?access_token=${token || ''}`
   );
   const data = await res.json();
   return data.features?.[0]?.place_name || `${lat.toFixed(4)}, ${lng.toFixed(4)}`;

--- a/src/utils/mapboxToken.ts
+++ b/src/utils/mapboxToken.ts
@@ -1,0 +1,12 @@
+export function getMapboxToken(): string | null {
+  const token = import.meta.env.VITE_MAPBOX_TOKEN as string | undefined;
+  if (!token) {
+    console.error('[Mapbox] VITE_MAPBOX_TOKEN is not set.');
+    return null;
+  }
+  if (!token.startsWith('pk.')) {
+    console.error('[Mapbox] VITE_MAPBOX_TOKEN should start with "pk."');
+    return null;
+  }
+  return token;
+}


### PR DESCRIPTION
## Summary
- centralize Mapbox token retrieval via `getMapboxToken`
- switch all Mapbox init to use the environment token
- handle missing/invalid Mapbox token and fallback to offline mode
- add `.env.example` and remove real token from repo
- allow `.env.example` via `.gitignore`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860da053d3c83239e4417faf25b99dd