### PR TITLE
Fix offline map overlay

### DIFF
--- a/src/components/wheels/trip-planner/MapControls.tsx
+++ b/src/components/wheels/trip-planner/MapControls.tsx
@@ -203,8 +203,8 @@ export default function MapControls({
       <div className="overflow-hidden rounded-lg border h-full">
         <div ref={mapContainer} className="h-full w-full relative" />
         {isOffline && (
-          <div className="absolute inset-0 bg-gray-100 bg-opacity-50 flex items-center justify-center">
-            <div className="bg-white p-4 rounded-lg shadow-lg text-center">
+          <div className="absolute inset-0 bg-gray-100 bg-opacity-50 flex items-center justify-center pointer-events-none">
+            <div className="bg-white p-4 rounded-lg shadow-lg text-center pointer-events-auto">
               <p className="text-gray-600">Map updates disabled in offline mode</p>
             </div>
           </div>

--- a/src/context/OfflineContext.tsx
+++ b/src/context/OfflineContext.tsx
@@ -1,5 +1,5 @@
 
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useState, useEffect } from 'react';
 
 interface OfflineContextType {
   isOffline: boolean;
@@ -10,7 +10,20 @@ interface OfflineContextType {
 const OfflineContext = createContext<OfflineContextType | undefined>(undefined);
 
 export const OfflineProvider = ({ children }: { children: React.ReactNode }) => {
-  const [isOffline, setIsOffline] = useState(false);
+  const [isOffline, setIsOffline] = useState(!navigator.onLine);
+
+  useEffect(() => {
+    const goOnline = () => setIsOffline(false);
+    const goOffline = () => setIsOffline(true);
+
+    window.addEventListener('online', goOnline);
+    window.addEventListener('offline', goOffline);
+
+    return () => {
+      window.removeEventListener('online', goOnline);
+      window.removeEventListener('offline', goOffline);
+    };
+  }, []);
 
   const setOffline = (offline: boolean) => {
     setIsOffline(offline);


### PR DESCRIPTION
## Summary
- improve offline detection by syncing with browser online status
- ensure map overlay doesn't block clicks and only appears when offline

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6860fb4990f083239ef58f7617764e71