### PR TITLE
Fix CSS import order causing build warning

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,6 @@
 @import "@mapbox/mapbox-gl-directions/dist/mapbox-gl-directions.css";
 @import "@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css";
+@import "mapbox-gl/dist/mapbox-gl.css";
 
 @import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;600;700&display=swap');
 
@@ -215,5 +216,3 @@
   ring-color: #3b82f6 !important;
   border-color: transparent !important;
 }
-/* Mapbox GL CSS - Import at the end to avoid conflicts */
-@import 'mapbox-gl/dist/mapbox-gl.css';


### PR DESCRIPTION
## Summary
- ensure Mapbox GL CSS `@import` is at the top of `src/index.css`

## Testing
- `npm run build`
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68631b796f1483238b2e4b8bc4711b8f