### PR TITLE
Add text-to-speech endpoint

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -1,5 +1,5 @@
-from . import auth, chat, health, monitoring, pam, social, wheels, wins, subscription
+from . import auth, chat, health, monitoring, pam, social, wheels, wins, subscription, voice
 
 __all__ = [
-    'auth', 'chat', 'health', 'monitoring', 'pam', 'social', 'wheels', 'wins', 'subscription'
+    'auth', 'chat', 'health', 'monitoring', 'pam', 'social', 'wheels', 'wins', 'subscription', 'voice'
 ]

--- a/backend/app/api/v1/voice.py
+++ b/backend/app/api/v1/voice.py
@@ -1,0 +1,38 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+import httpx
+
+from app.core.config import get_settings
+from app.core.logging import setup_logging
+
+router = APIRouter()
+logger = setup_logging()
+
+class VoiceRequest(BaseModel):
+    text: str
+
+class VoiceResponse(BaseModel):
+    audio: list[int]
+    duration: int
+    cached: bool
+
+@router.post("/voice", response_model=VoiceResponse)
+async def generate_voice(payload: VoiceRequest):
+    """Generate speech audio from text via Supabase function."""
+    settings = get_settings()
+    supabase_url = settings.SUPABASE_URL.rstrip('/')
+    function_url = f"{supabase_url}/functions/v1/nari-dia-tts"
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {settings.SUPABASE_KEY}",
+        "apikey": settings.SUPABASE_KEY,
+    }
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.post(function_url, json={"text": payload.text}, headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+            return VoiceResponse(**data)
+    except Exception as e:
+        logger.error(f"TTS generation failed: {e}")
+        raise HTTPException(status_code=500, detail="Failed to generate audio")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,7 +25,7 @@ from app.services.monitoring_service import monitoring_service
 from app.services.sentry_service import sentry_service
 
 # Import API routers
-from app.api.v1 import health, chat, wins, wheels, social, monitoring, pam, auth, subscription
+from app.api.v1 import health, chat, wins, wheels, social, monitoring, pam, auth, subscription, voice
 
 logger = setup_logging()
 
@@ -109,6 +109,7 @@ app.include_router(wins.router, prefix="/api", tags=["Wins"])
 app.include_router(wheels.router, prefix="/api", tags=["Wheels"])
 app.include_router(social.router, prefix="/api", tags=["Social"])
 app.include_router(pam.router, prefix="/api", tags=["PAM"])
+app.include_router(voice.router, prefix="/api", tags=["Voice"])
 app.include_router(auth.router, prefix="/api/auth", tags=["Authentication"])
 app.include_router(subscription.router, prefix="/api/v1", tags=["Subscription"])
 


### PR DESCRIPTION
## Summary
- add voice router for text-to-speech
- wire voice router into API package and main app

## Testing
- `pytest backend -q` *(fails: ModuleNotFoundError: No module named 'app.database')*

------
https://chatgpt.com/codex/tasks/task_e_68633302c370832395a9db9d52e616ed