### PR TITLE
Fix CORS defaults to avoid preflight 400s

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -21,6 +21,8 @@ DEBUG=False
 SECRET_KEY=your_secret_key_here
 
 # CORS settings
-ALLOWED_ORIGINS=["https://yourdomain.com", "https://www.yourdomain.com"]
+# Default to allowing any origin. Replace "*" with a comma separated
+# list of your frontend domains in production.
+ALLOWED_ORIGINS=["*"]
 VITE_BACKEND_URL=https://pam-backend.onrender.com
 VITE_MAPBOX_TOKEN=pk.eyJ1IjoidGhhYm9uZWwiLCJhIjoiY204d3lwMnhwMDBmdTJqb2JsdWgzdmZ2YyJ9.0wyj48txMJAJht1kYfyOdQ

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -23,11 +23,10 @@ class Settings(BaseSettings):
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
     
     # CORS
-    ALLOWED_ORIGINS: List[str] = [
-        "http://localhost:3000",
-        "https://wheelsandwins.com",
-        "https://www.wheelsandwins.com"
-    ]
+    # Allow all origins by default to prevent CORS preflight errors.
+    # Override in production by setting the ALLOWED_ORIGINS environment variable
+    # with a comma separated list or JSON array of allowed domains.
+    ALLOWED_ORIGINS: List[str] = ["*"]
     
     # Redis (for future use)
     REDIS_URL: str = "redis://localhost:6379"

--- a/docs/guides/troubleshooting/api-errors.md
+++ b/docs/guides/troubleshooting/api-errors.md
@@ -75,6 +75,8 @@ This guide helps diagnose and resolve API-related errors in the PAM system.
 **Solutions**:
 - Add frontend URL to `ALLOWED_ORIGINS`
 - Check CORS middleware configuration
+- 400 Bad Request on an `OPTIONS` request usually means the origin isn't allowed.
+  Ensure your domain is listed in `ALLOWED_ORIGINS` or use `[*]` during testing.
 - Verify preflight request handling
 - Test with different browsers
 


### PR DESCRIPTION
## Summary
- allow any origin by default to avoid CORS preflight failures
- document CORS errors in troubleshooting guide
- update example `.env.production` with wildcard origin

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_686355feb2508323afcdefd296d91889