### PR TITLE
Add project guide

### DIFF
--- a/docs/Project_Guide.md
+++ b/docs/Project_Guide.md
@@ -1,0 +1,18 @@
+# Project Guide
+
+This document provides a high level overview of the Wheels and Wins project and explains how to keep the documentation up to date.
+
+## Documentation Workflow
+
+- All project documentation lives in the `docs/` directory.
+- Individual topics are organized into subfolders such as `features`, `guides`, and `technical`.
+- When adding new articles, follow the formatting style used in the existing files.
+- Use descriptive headings, bullet lists, and code blocks where appropriate.
+
+## Keeping This Guide Updated
+
+This file is intended to be a living resource. Place it in the `docs/` folder so it can be edited as the project evolves. Submit a pull request any time you add or modify sections so the team can review your updates.
+
+## Additional Resources
+
+See `README.md` at the project root for details on setting up the environment and running the application.


### PR DESCRIPTION
## Summary
- add a new `docs/Project_Guide.md` with high level overview and documentation workflow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_6863901d34ac8323bb16db722feb851c