### PR TITLE
Add Supabase real-time trip sync

### DIFF
--- a/docs/features/travel-vehicles.md
+++ b/docs/features/travel-vehicles.md
@@ -79,6 +79,7 @@ src/components/wheels/trip-planner/
 - **Cost Estimation**: Fuel and travel expense calculations
 - **Offline Support**: Cached trip data and basic offline functionality
 - **PAM Integration**: AI-powered trip suggestions and optimization
+- **Real-time Sync**: Share and edit trip plans across devices
 
 ### Vehicle Maintenance
 - **Service Tracking**: Complete maintenance history logging

--- a/src/components/wheels/TripPlanner.tsx
+++ b/src/components/wheels/TripPlanner.tsx
@@ -15,6 +15,7 @@ import LockedPointControls from "./trip-planner/LockedPointControls";
 import WeatherWidget from "./WeatherWidget";
 import { useTripPlannerState } from "./trip-planner/hooks/useTripPlannerState";
 import { useTripPlannerHandlers } from "./trip-planner/hooks/useTripPlannerHandlers";
+import useTripSync from "./trip-planner/hooks/useTripSync";
 import { Button } from "@/components/ui/button";
 import { Cloud } from "lucide-react";
 
@@ -55,6 +56,8 @@ export default function TripPlanner() {
     mode,
     setMode,
     saveTripData,
+    tripId,
+    setTripId,
     originLocked,
     destinationLocked,
     lockOrigin,
@@ -62,6 +65,15 @@ export default function TripPlanner() {
     unlockOrigin,
     unlockDestination
   } = useTripPlannerState(isOffline);
+
+  useTripSync({
+    tripId,
+    map,
+    directionsControl,
+    setOriginName,
+    setDestName,
+    setWaypoints
+  });
 
   // Event handlers
   const {
@@ -75,7 +87,9 @@ export default function TripPlanner() {
     setSuggestions,
     saveTripData,
     routeProfile,
-    mode
+    mode,
+    tripId,
+    setTripId
   });
 
   // Get weather for route destination
@@ -123,7 +137,27 @@ export default function TripPlanner() {
       
 
       {/* Unified Controls Section */}
-      <TripPlannerControls directionsControl={directionsControl} originName={originName} destName={destName} setOriginName={setOriginName} setDestName={setDestName} travelMode={travelMode} setTravelMode={setTravelMode} mode={mode} setMode={setMode} adding={adding} setAdding={setAdding} onSubmitTrip={handleSubmitTrip} map={map} isOffline={isOffline} originLocked={originLocked} destinationLocked={destinationLocked} lockOrigin={lockOrigin} lockDestination={lockDestination} />
+      <TripPlannerControls
+        directionsControl={directionsControl}
+        originName={originName}
+        destName={destName}
+        setOriginName={setOriginName}
+        setDestName={setDestName}
+        travelMode={travelMode}
+        setTravelMode={setTravelMode}
+        mode={mode}
+        setMode={setMode}
+        adding={adding}
+        setAdding={setAdding}
+        onSubmitTrip={handleSubmitTrip}
+        map={map}
+        isOffline={isOffline}
+        originLocked={originLocked}
+        destinationLocked={destinationLocked}
+        lockOrigin={lockOrigin}
+        lockDestination={lockDestination}
+        tripId={tripId}
+      />
 
       {/* Weather Widget Sidebar */}
       {showWeather && weatherLocation && <div className="bg-white rounded-lg border p-4">

--- a/src/components/wheels/trip-planner/TripControls.tsx
+++ b/src/components/wheels/trip-planner/TripControls.tsx
@@ -10,6 +10,7 @@ interface TripControlsProps {
   onSubmitTrip: () => void;
   map: React.MutableRefObject<mapboxgl.Map | undefined>;
   isOffline?: boolean;
+  tripId?: string | null;
 }
 
 export default function TripControls({
@@ -20,6 +21,7 @@ export default function TripControls({
   onSubmitTrip,
   map,
   isOffline = false,
+  tripId,
 }: TripControlsProps) {
   return (
     <div className="space-y-3">
@@ -68,6 +70,18 @@ export default function TripControls({
         >
           {isOffline ? "Queue for Pam" : "Send to Pam"}
         </Button>
+        {tripId && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              const url = `${window.location.origin}/share/trip/${tripId}`;
+              navigator.clipboard.writeText(url).catch(console.error);
+            }}
+          >
+            Share Trip
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/src/components/wheels/trip-planner/TripPlannerControls.tsx
+++ b/src/components/wheels/trip-planner/TripPlannerControls.tsx
@@ -22,6 +22,7 @@ interface TripPlannerControlsProps {
   destinationLocked?: boolean;
   lockOrigin?: () => void;
   lockDestination?: () => void;
+  tripId?: string | null;
 }
 export default function TripPlannerControls({
   directionsControl,
@@ -41,7 +42,8 @@ export default function TripPlannerControls({
   originLocked = false,
   destinationLocked = false,
   lockOrigin,
-  lockDestination
+  lockDestination,
+  tripId
 }: TripPlannerControlsProps) {
   return <div className="bg-white rounded-lg border p-4">
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
@@ -54,7 +56,16 @@ export default function TripPlannerControls({
         {/* Trip Controls */}
         <div className="lg:col-span-1">
           <h3 className="text-sm font-medium text-gray-700 mb-3">Actions</h3>
-          <TripControls mode={mode} setMode={setMode} adding={adding} setAdding={setAdding} onSubmitTrip={onSubmitTrip} map={map} isOffline={isOffline} />
+          <TripControls
+            mode={mode}
+            setMode={setMode}
+            adding={adding}
+            setAdding={setAdding}
+            onSubmitTrip={onSubmitTrip}
+            map={map}
+            isOffline={isOffline}
+            tripId={tripId}
+          />
         </div>
       </div>
     </div>;

--- a/src/components/wheels/trip-planner/TripService.tsx
+++ b/src/components/wheels/trip-planner/TripService.tsx
@@ -57,15 +57,43 @@ export class TripService {
     suggestions: Suggestion[],
     mode: string,
     waypoints: Waypoint[]
+  ): Promise<string | null> {
+    const { data, error } = await supabase
+      .from("group_trips")
+      .insert({
+        created_by: userId,
+        trip_name: `${originName} to ${destName}`,
+        description: `Trip from ${originName} to ${destName}`,
+        start_date: new Date().toISOString(),
+        end_date: new Date().toISOString(),
+        route_data: JSON.stringify({ origin, dest, routingProfile, suggestions, waypoints }),
+        status: 'active'
+      })
+      .select('id')
+      .single();
+
+    if (error) {
+      console.error('Error saving trip:', error);
+      return null;
+    }
+    return data?.id ?? null;
+  }
+
+  static async updateTripRoute(
+    tripId: string,
+    origin: [number, number],
+    dest: [number, number],
+    routingProfile: string,
+    suggestions: Suggestion[],
+    mode: string,
+    waypoints: Waypoint[]
   ): Promise<void> {
-    await supabase.from("group_trips").insert({
-      created_by: userId,
-      trip_name: `${originName} to ${destName}`,
-      description: `Trip from ${originName} to ${destName}`,
-      start_date: new Date().toISOString(),
-      end_date: new Date().toISOString(),
-      route_data: JSON.stringify({ origin, dest, routingProfile, suggestions, waypoints }),
-      status: 'active'
-    });
+    await supabase
+      .from('group_trips')
+      .update({
+        route_data: JSON.stringify({ origin, dest, routingProfile, suggestions, waypoints, mode }),
+        updated_at: new Date().toISOString()
+      })
+      .eq('id', tripId);
   }
 }

--- a/src/components/wheels/trip-planner/hooks/useIntegratedTripState.ts
+++ b/src/components/wheels/trip-planner/hooks/useIntegratedTripState.ts
@@ -46,6 +46,7 @@ export interface IntegratedTripState {
     activeFeature: 'route' | 'budget' | 'social' | 'pam' | 'export' | 'meetup' | null;
   };
   sync: boolean;
+  tripId: string | null;
 }
 
 export function useIntegratedTripState(isOffline: boolean) {
@@ -87,6 +88,7 @@ export function useIntegratedTripState(isOffline: boolean) {
 
   // Sync state - indicates if all features are in sync
   const [isInSync, setIsInSync] = useState(true);
+  const [tripId, setTripId] = useState<string | null>(null);
 
   // Cross-feature intelligence functions
   const updateBudgetFromRoute = useCallback((distance: number, days: number) => {
@@ -180,6 +182,7 @@ export function useIntegratedTripState(isOffline: boolean) {
     export: exportData,
     ui: uiState,
     sync: isInSync,
+    tripId,
   };
 
   return {
@@ -194,5 +197,7 @@ export function useIntegratedTripState(isOffline: boolean) {
     setUIState,
     // Original trip state actions
     ...tripState,
+    tripId,
+    setTripId,
   };
 }

--- a/src/components/wheels/trip-planner/hooks/useTripPlannerState.ts
+++ b/src/components/wheels/trip-planner/hooks/useTripPlannerState.ts
@@ -17,6 +17,7 @@ export function useTripPlannerState(isOffline: boolean) {
   const [travelMode, setTravelMode] = useState("driving");
   const [routeProfile, setRouteProfile] = useState("driving");
   const [mode, setMode] = useState("driving");
+  const [tripId, setTripId] = useState<string | null>(null);
 
   // Load cached data on mount
   useEffect(() => {
@@ -48,6 +49,8 @@ export function useTripPlannerState(isOffline: boolean) {
     mode,
     setMode,
     saveTripData,
+    tripId,
+    setTripId,
     ...lockedPointsState,
   };
 }

--- a/src/components/wheels/trip-planner/hooks/useTripSync.ts
+++ b/src/components/wheels/trip-planner/hooks/useTripSync.ts
@@ -1,0 +1,63 @@
+import { useEffect } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+import mapboxgl from 'mapbox-gl';
+import MapboxDirections from '@mapbox/mapbox-gl-directions/dist/mapbox-gl-directions';
+import { Waypoint } from '../types';
+
+interface UseTripSyncProps {
+  tripId: string | null;
+  map: React.MutableRefObject<mapboxgl.Map | undefined>;
+  directionsControl: React.MutableRefObject<MapboxDirections | undefined>;
+  setOriginName: (name: string) => void;
+  setDestName: (name: string) => void;
+  setWaypoints: (wps: Waypoint[]) => void;
+}
+
+export function useTripSync({
+  tripId,
+  map,
+  directionsControl,
+  setOriginName,
+  setDestName,
+  setWaypoints
+}: UseTripSyncProps) {
+  useEffect(() => {
+    if (!tripId) return;
+
+    const channel = supabase
+      .channel(`group_trips:${tripId}`)
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'group_trips', filter: `id=eq.${tripId}` },
+        payload => {
+          try {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const updated = payload.new as any;
+            if (!updated || !updated.route_data) return;
+            const route = JSON.parse(updated.route_data);
+            if (route.origin?.name) setOriginName(route.origin.name);
+            if (route.dest?.name) setDestName(route.dest.name);
+            const wps: Waypoint[] = route.waypoints || [];
+            setWaypoints(wps);
+            if (directionsControl.current) {
+              directionsControl.current.setOrigin(route.origin.coords);
+              directionsControl.current.setDestination(route.dest.coords);
+              directionsControl.current.removeWaypoints();
+              wps.forEach((wp, idx) => {
+                directionsControl.current!.addWaypoint(idx + 1, wp.coords);
+              });
+            }
+          } catch (err) {
+            console.error('Error applying trip update', err);
+          }
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel).catch(console.error);
+    };
+  }, [tripId, map, directionsControl, setOriginName, setDestName, setWaypoints]);
+}
+
+export default useTripSync;


### PR DESCRIPTION
## Summary
- add `useTripSync` hook to subscribe to trip updates
- track `tripId` in trip planner state and integrated state
- update TripService with trip update API
- sync map and itinerary via Supabase in `TripPlanner`
- provide share button for current trip
- document real-time sync feature

## Testing
- `npm run lint` *(fails: cannot find ESLint packages)*
- `npm run type-check` *(fails: missing script)*
- `npm run test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863eae6fbb4832397f270647ce385f9