### PR TITLE
Fix duplicate accessToken assignment

### DIFF
--- a/src/components/wheels/trip-planner/MapControls.tsx
+++ b/src/components/wheels/trip-planner/MapControls.tsx
@@ -63,7 +63,6 @@ export default function MapControls({
     if (!map.current) {
       console.log('Initializing map with token:', import.meta.env.VITE_MAPBOX_TOKEN ? 'Token present' : 'Token missing');
       mapboxgl.accessToken = import.meta.env.VITE_MAPBOX_TOKEN;
-      mapboxgl.accessToken = import.meta.env.VITE_MAPBOX_TOKEN;
       
       map.current = new mapboxgl.Map({
         container: mapContainer.current,


### PR DESCRIPTION
## Summary
- initialize the Mapbox access token only once in `MapControls`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867219f87088323b8a8ef8ea232a368