### PR TITLE
Add TripStats component

### DIFF
--- a/src/components/wheels/TripPlanner.tsx
+++ b/src/components/wheels/TripPlanner.tsx
@@ -10,6 +10,7 @@ import SuggestionsGrid from "./trip-planner/SuggestionsGrid";
 import TripPlannerHeader from "./trip-planner/TripPlannerHeader";
 import TripPlannerControls from "./trip-planner/TripPlannerControls";
 import TripPlannerTip from "./trip-planner/TripPlannerTip";
+import TripStats from "./trip-planner/TripStats";
 import TripPlannerLayout from "./trip-planner/TripPlannerLayout";
 import LockedPointControls from "./trip-planner/LockedPointControls";
 import WeatherWidget from "./WeatherWidget";
@@ -132,6 +133,8 @@ export default function TripPlanner() {
             </Button>
           </div>}
       </div>
+
+      <TripStats directionsControl={directionsControl} />
 
       {/* Search Section */}
       

--- a/src/components/wheels/trip-planner/IntegratedTripPlanner.tsx
+++ b/src/components/wheels/trip-planner/IntegratedTripPlanner.tsx
@@ -8,6 +8,7 @@ import WaypointsList from "./WaypointsList";
 import SuggestionsGrid from "./SuggestionsGrid";
 import LockedPointControls from "./LockedPointControls";
 import MapControls from "./MapControls";
+import TripStats from "./TripStats";
 import { useIntegratedTripState } from "./hooks/useIntegratedTripState";
 import { useTripPlannerHandlers } from "./hooks/useTripPlannerHandlers";
 import { PAMProvider } from "./PAMContext";
@@ -127,9 +128,9 @@ export default function IntegratedTripPlanner({ isOffline = false }: IntegratedT
             isOffline={isOffline}
             originLocked={integratedState.originLocked}
             destinationLocked={integratedState.destinationLocked}
-            lockOrigin={integratedState.lockOrigin}
-            lockDestination={integratedState.lockDestination}
-          />
+          lockOrigin={integratedState.lockOrigin}
+          lockDestination={integratedState.lockDestination}
+        />
         ) : (
           <div className="h-[60vh] lg:h-[70vh] relative">
             <div className="overflow-hidden rounded-lg border h-full bg-gradient-to-br from-blue-50 to-blue-100">
@@ -175,6 +176,8 @@ export default function IntegratedTripPlanner({ isOffline = false }: IntegratedT
             </div>
           </div>
         )}
+
+        <TripStats directionsControl={directionsControl} />
 
         {/* Waypoints List */}
         {integratedState.route.waypoints.length > 0 && (

--- a/src/components/wheels/trip-planner/TripStats.tsx
+++ b/src/components/wheels/trip-planner/TripStats.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from "react";
+import MapboxDirections from "@mapbox/mapbox-gl-directions/dist/mapbox-gl-directions";
+import { useUserUnits } from "./hooks/useUserUnits";
+
+interface TripStatsProps {
+  directionsControl: React.MutableRefObject<MapboxDirections | undefined>;
+}
+
+const MPG = 8.5; // default mpg for fuel estimate
+const KM_PER_MILE = 1.60934;
+const L_PER_GALLON = 3.78541;
+
+export default function TripStats({ directionsControl }: TripStatsProps) {
+  const { units } = useUserUnits();
+  const [distance, setDistance] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [fuel, setFuel] = useState(0);
+
+  useEffect(() => {
+    if (!directionsControl?.current) return;
+    const dir = directionsControl.current;
+
+    const updateStats = () => {
+      try {
+        const route = (dir as any).getRoute?.();
+        if (route && route[0] && route[0].legs) {
+          const totalDistance = route[0].legs.reduce(
+            (sum: number, leg: any) => sum + (leg.distance || 0),
+            0,
+          );
+          const totalDuration = route[0].legs.reduce(
+            (sum: number, leg: any) => sum + (leg.duration || 0),
+            0,
+          );
+          const distKm = totalDistance / 1000;
+          const distMiles = distKm / KM_PER_MILE;
+
+          setDistance(units === "imperial" ? distMiles : distKm);
+          setDuration(totalDuration / 3600);
+
+          const gallons = distMiles / MPG;
+          const liters = gallons * L_PER_GALLON;
+          setFuel(units === "imperial" ? gallons : liters);
+        }
+      } catch (err) {
+        console.warn("Error computing trip stats", err);
+      }
+    };
+
+    dir.on("route", updateStats);
+    updateStats();
+    return () => {
+      dir.off("route", updateStats);
+    };
+  }, [directionsControl, units]);
+
+  if (!directionsControl?.current) return null;
+
+  return (
+    <div className="bg-white rounded-lg border p-4">
+      <h4 className="font-semibold mb-2">Trip Stats</h4>
+      <div className="flex flex-wrap gap-4 text-sm">
+        <div>
+          <span className="font-medium">Distance:</span> {distance.toFixed(1)}{" "}
+          {units === "imperial" ? "mi" : "km"}
+        </div>
+        <div>
+          <span className="font-medium">Duration:</span> {duration.toFixed(1)}{" "}
+          hrs
+        </div>
+        <div>
+          <span className="font-medium">Fuel:</span> {fuel.toFixed(1)}{" "}
+          {units === "imperial" ? "gal" : "L"}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add TripStats for distance, duration and fuel calculations
- show TripStats panel in TripPlanner and IntegratedTripPlanner

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run type-check`
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6868613888908323a8bbe899c88ca9a8