### PR TITLE
Add POI layer with filter controls

### DIFF
--- a/data/poi/pois.json
+++ b/data/poi/pois.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": 1,
+    "name": "Happy Paws Rest Area",
+    "category": "pet_stop",
+    "latitude": 34.9892,
+    "longitude": -115.492,
+    "description": "Small park with dog-friendly amenities."},
+  {
+    "id": 2,
+    "name": "Roadside Vet Clinic",
+    "category": "medical",
+    "latitude": 36.1147,
+    "longitude": -115.1728,
+    "description": "24/7 veterinary services for travelers."},
+  {
+    "id": 3,
+    "name": "Big Rig Parking",
+    "category": "wide_parking",
+    "latitude": 35.222,
+    "longitude": -111.646,
+    "description": "Extra-wide parking area for RVs."},
+  {
+    "id": 4,
+    "name": "Town Farmers Market",
+    "category": "farmers_market",
+    "latitude": 34.0522,
+    "longitude": -118.2437,
+    "description": "Open weekends with fresh local produce."},
+  {
+    "id": 5,
+    "name": "Paws and Go",
+    "category": "pet_stop",
+    "latitude": 37.7749,
+    "longitude": -122.4194,
+    "description": "Pet relief area with fenced run."},
+  {
+    "id": 6,
+    "name": "Overnight RV Lot",
+    "category": "wide_parking",
+    "latitude": 39.7392,
+    "longitude": -104.9903,
+    "description": "Spacious overnight parking for large rigs."},
+  {
+    "id": 7,
+    "name": "Highway Medical Center",
+    "category": "medical",
+    "latitude": 38.9072,
+    "longitude": -77.0369,
+    "description": "Emergency medical services close to the freeway."},
+  {
+    "id": 8,
+    "name": "Green Valley Market",
+    "category": "farmers_market",
+    "latitude": 40.7128,
+    "longitude": -74.0060,
+    "description": "Seasonal farmers market with organic goods."}
+]

--- a/src/components/wheels/trip-planner/MapOptionsControl.ts
+++ b/src/components/wheels/trip-planner/MapOptionsControl.ts
@@ -6,6 +6,8 @@ import MapOptionsDropdown from './MapOptionsDropdown';
 interface MapOptionsControlOptions {
   onStyleChange: (style: string) => void;
   currentStyle: string;
+  poiFilters: Record<string, boolean>;
+  onPOIFilterChange: (filters: Record<string, boolean>) => void;
 }
 
 export class MapOptionsControl implements mapboxgl.IControl {
@@ -50,7 +52,9 @@ export class MapOptionsControl implements mapboxgl.IControl {
         map: mapRef,
         onStyleChange: this.options.onStyleChange,
         currentStyle: this.options.currentStyle,
-        isMapControl: true // Add this prop to style it differently as a map control
+        isMapControl: true, // Add this prop to style it differently as a map control
+        poiFilters: this.options.poiFilters,
+        onPOIFilterChange: this.options.onPOIFilterChange
       })
     );
   }

--- a/src/components/wheels/trip-planner/MapOptionsDropdown.tsx
+++ b/src/components/wheels/trip-planner/MapOptionsDropdown.tsx
@@ -1,6 +1,22 @@
 import React, { useState, useEffect } from 'react';
 import mapboxgl from 'mapbox-gl';
-import { ChevronDown, Settings, Satellite, Mountain, MapPin, Zap, Phone, TreePine, Shield, Cloud, Flame } from 'lucide-react';
+import {
+  ChevronDown,
+  Settings,
+  Satellite,
+  Mountain,
+  MapPin,
+  Zap,
+  Phone,
+  TreePine,
+  Shield,
+  Cloud,
+  Flame,
+  Bone,
+  CircleParking,
+  Ambulance,
+  Carrot
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -19,9 +35,11 @@ interface MapOptionsDropdownProps {
   onStyleChange: (style: string) => void;
   currentStyle: string;
   isMapControl?: boolean; // New prop to indicate if this is a native map control
+  poiFilters?: Record<string, boolean>;
+  onPOIFilterChange?: (filters: Record<string, boolean>) => void;
 }
 
-export default function MapOptionsDropdown({ map, onStyleChange, currentStyle, isMapControl = false }: MapOptionsDropdownProps) {
+export default function MapOptionsDropdown({ map, onStyleChange, currentStyle, isMapControl = false, poiFilters, onPOIFilterChange }: MapOptionsDropdownProps) {
   const [baseMapStyle, setBaseMapStyle] = useState('satellite');
   // Fixed to scenic theme as requested
   const baseMapTheme = 'scenic';
@@ -34,6 +52,20 @@ export default function MapOptionsDropdown({ map, onStyleChange, currentStyle, i
     smoke: false,
     fires: false,
   });
+  const [poiState, setPoiState] = useState<Record<string, boolean>>(
+    poiFilters || {
+      pet_stop: true,
+      wide_parking: true,
+      medical: true,
+      farmers_market: true
+    }
+  );
+
+  useEffect(() => {
+    if (poiFilters) {
+      setPoiState(poiFilters);
+    }
+  }, [poiFilters]);
 
   // Detect user's country based on map center
   useEffect(() => {
@@ -159,6 +191,12 @@ export default function MapOptionsDropdown({ map, onStyleChange, currentStyle, i
     }
 
     // Add logic for other overlays here as needed
+  };
+
+  const handlePOIToggle = (key: string, checked: boolean) => {
+    const updated = { ...poiState, [key]: checked };
+    setPoiState(updated);
+    if (onPOIFilterChange) onPOIFilterChange(updated);
   };
 
   const getPublicLandsForCountry = () => {
@@ -321,6 +359,53 @@ export default function MapOptionsDropdown({ map, onStyleChange, currentStyle, i
             <Flame className="w-3 h-3 text-orange-600" />
           </div>
           <span>Fires</span>
+        </DropdownMenuCheckboxItem>
+
+        <DropdownMenuSeparator />
+
+        {/* Points of Interest */}
+        <DropdownMenuLabel className="text-sm font-semibold text-gray-700">
+          Points of Interest
+        </DropdownMenuLabel>
+        <DropdownMenuCheckboxItem
+          checked={poiState.pet_stop}
+          onCheckedChange={(checked) => handlePOIToggle('pet_stop', checked)}
+          className="flex items-center gap-3 py-2"
+        >
+          <div className="w-6 h-6 bg-yellow-100 rounded flex items-center justify-center">
+            <Bone className="w-3 h-3 text-yellow-600" />
+          </div>
+          <span>Pet Stops</span>
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem
+          checked={poiState.wide_parking}
+          onCheckedChange={(checked) => handlePOIToggle('wide_parking', checked)}
+          className="flex items-center gap-3 py-2"
+        >
+          <div className="w-6 h-6 bg-blue-100 rounded flex items-center justify-center">
+            <CircleParking className="w-3 h-3 text-blue-600" />
+          </div>
+          <span>Wide Parking</span>
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem
+          checked={poiState.medical}
+          onCheckedChange={(checked) => handlePOIToggle('medical', checked)}
+          className="flex items-center gap-3 py-2"
+        >
+          <div className="w-6 h-6 bg-red-100 rounded flex items-center justify-center">
+            <Ambulance className="w-3 h-3 text-red-600" />
+          </div>
+          <span>Medical</span>
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem
+          checked={poiState.farmers_market}
+          onCheckedChange={(checked) => handlePOIToggle('farmers_market', checked)}
+          className="flex items-center gap-3 py-2"
+        >
+          <div className="w-6 h-6 bg-green-100 rounded flex items-center justify-center">
+            <Carrot className="w-3 h-3 text-green-600" />
+          </div>
+          <span>Farmers Markets</span>
         </DropdownMenuCheckboxItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/components/wheels/trip-planner/POILayer.tsx
+++ b/src/components/wheels/trip-planner/POILayer.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useRef, useState } from 'react';
+import mapboxgl from 'mapbox-gl';
+import { POI } from './types';
+
+interface POILayerProps {
+  map: React.MutableRefObject<mapboxgl.Map | undefined>;
+  filters: Record<string, boolean>;
+}
+
+export default function POILayer({ map, filters }: POILayerProps) {
+  const [pois, setPois] = useState<POI[]>([]);
+  const markersRef = useRef<mapboxgl.Marker[]>([]);
+
+  useEffect(() => {
+    fetch('/data/poi/pois.json')
+      .then(res => res.json())
+      .then(setPois)
+      .catch(err => console.error('Failed to load POIs', err));
+  }, []);
+
+  useEffect(() => {
+    if (!map.current) return;
+
+    markersRef.current.forEach(m => m.remove());
+    markersRef.current = [];
+
+    pois.forEach(poi => {
+      if (!filters[poi.category]) return;
+
+      const el = document.createElement('div');
+      el.className = 'poi-marker';
+      el.style.fontSize = '20px';
+      el.textContent = getIcon(poi.category);
+
+      const marker = new mapboxgl.Marker({ element: el })
+        .setLngLat([poi.longitude, poi.latitude])
+        .addTo(map.current!);
+
+      const popup = new mapboxgl.Popup({ offset: 25 }).setHTML(
+        `<div class="p-2 text-sm"><div class="font-semibold mb-1">${poi.name}</div><div>${poi.description}</div></div>`
+      );
+      marker.getElement().addEventListener('click', () => popup.addTo(map.current!));
+
+      markersRef.current.push(marker);
+    });
+
+    return () => {
+      markersRef.current.forEach(m => m.remove());
+      markersRef.current = [];
+    };
+  }, [map, pois, filters]);
+
+  return null;
+}
+
+function getIcon(category: string): string {
+  switch (category) {
+    case 'pet_stop':
+      return '🐾';
+    case 'wide_parking':
+      return '🅿️';
+    case 'medical':
+      return '🚑';
+    case 'farmers_market':
+      return '🥕';
+    default:
+      return '📍';
+  }
+}

--- a/src/components/wheels/trip-planner/types.ts
+++ b/src/components/wheels/trip-planner/types.ts
@@ -28,3 +28,12 @@ export interface RouteState {
   totalDistance?: number;
   estimatedTime?: number;
 }
+
+export interface POI {
+  id: number;
+  name: string;
+  category: string;
+  latitude: number;
+  longitude: number;
+  description: string;
+}


### PR DESCRIPTION
## Summary
- add sample POI dataset
- support POI types in Trip Planner options dropdown
- allow updating POI filter settings from Map Options control
- overlay POIs on the map with a new POILayer component

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686861374b9483238fe4aaead60def71