### PR TITLE
Implement password reset workflow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,8 @@ import { Toaster } from 'sonner';
 import PaymentSuccess from "@/pages/PaymentSuccess";
 import PaymentCanceled from "@/pages/PaymentCanceled";
 import CancelTrial from "@/pages/CancelTrial";
+import PasswordResetRequest from "@/pages/PasswordResetRequest";
+import UpdatePassword from "@/pages/UpdatePassword";
 import ProtectedRoute from './components/ProtectedRoute';
 
 const queryClient = new QueryClient();
@@ -54,6 +56,8 @@ function App() {
                         <Route path="/payment-success" element={<PaymentSuccess />} />
                         <Route path="/payment-canceled" element={<PaymentCanceled />} />
                         <Route path="/cancel-trial" element={<CancelTrial />} />
+                        <Route path="/reset-password" element={<PasswordResetRequest />} />
+                        <Route path="/update-password" element={<UpdatePassword />} />
                       </Routes>
                     </Layout>
                   </WheelsProvider>

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,5 +1,6 @@
 
 import { useState } from "react";
+import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -70,10 +71,12 @@ const LoginForm = ({ loading, setLoading, error, setError, onSuccess }: LoginFor
         <div className="space-y-2">
           <div className="flex justify-between">
             <Label htmlFor="password">Password</Label>
-            <a href="#" className="text-sm text-blue-600 hover:text-blue-800" onClick={(e) => {
-              e.preventDefault();
-              alert("Password reset functionality coming soon!");
-            }}>Forgot password?</a>
+            <Link
+              to="/reset-password"
+              className="text-sm text-blue-600 hover:text-blue-800"
+            >
+              Forgot password?
+            </Link>
           </div>
           <PasswordInput
             id="password"

--- a/src/components/auth/PasswordResetRequestForm.tsx
+++ b/src/components/auth/PasswordResetRequestForm.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { supabase } from "@/integrations/supabase/client";
+
+interface PasswordResetRequestFormProps {
+  onSent?: () => void;
+}
+
+const PasswordResetRequestForm = ({ onSent }: PasswordResetRequestFormProps) => {
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sent, setSent] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    try {
+      if (!email) throw new Error("Please enter your email");
+      setLoading(true);
+
+      const redirectTo = `${window.location.origin}/update-password`;
+      const { error } = await supabase.auth.resetPasswordForEmail(email, {
+        redirectTo,
+      });
+      if (error) throw error;
+
+      setSent(true);
+      onSent?.();
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (sent) {
+    return (
+      <Alert>
+        <AlertDescription>
+          If an account exists for {email}, a password reset link has been sent.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+      <div className="space-y-2">
+        <Label htmlFor="email">Email</Label>
+        <Input
+          id="email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="you@example.com"
+          required
+          disabled={loading}
+        />
+      </div>
+      <Button type="submit" className="w-full" disabled={loading}>
+        {loading ? "Sending..." : "Send Reset Link"}
+      </Button>
+    </form>
+  );
+};
+
+export default PasswordResetRequestForm;

--- a/src/components/auth/UpdatePasswordForm.tsx
+++ b/src/components/auth/UpdatePasswordForm.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { supabase } from "@/integrations/supabase/client";
+
+interface UpdatePasswordFormProps {
+  onSuccess?: () => void;
+}
+
+const UpdatePasswordForm = ({ onSuccess }: UpdatePasswordFormProps) => {
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [updated, setUpdated] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (password !== confirmPassword) {
+      setError("Passwords do not match");
+      return;
+    }
+
+    try {
+      setLoading(true);
+      const { error } = await supabase.auth.updateUser({ password });
+      if (error) throw error;
+      setUpdated(true);
+      onSuccess?.();
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (updated) {
+    return (
+      <Alert>
+        <AlertDescription>Password updated successfully.</AlertDescription>
+      </Alert>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+      <div className="space-y-2">
+        <Label htmlFor="password">New Password</Label>
+        <Input
+          id="password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          disabled={loading}
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="confirmPassword">Confirm Password</Label>
+        <Input
+          id="confirmPassword"
+          type="password"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          required
+          disabled={loading}
+        />
+      </div>
+      <Button type="submit" className="w-full" disabled={loading}>
+        {loading ? "Updating..." : "Update Password"}
+      </Button>
+    </form>
+  );
+};
+
+export default UpdatePasswordForm;

--- a/src/pages/PasswordResetRequest.tsx
+++ b/src/pages/PasswordResetRequest.tsx
@@ -1,0 +1,20 @@
+import PasswordResetRequestForm from "@/components/auth/PasswordResetRequestForm";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+
+const PasswordResetRequest = () => {
+  return (
+    <div className="container max-w-md mx-auto px-4 py-16">
+      <Card className="w-full">
+        <CardHeader className="space-y-1 text-center">
+          <CardTitle className="text-2xl font-bold">Reset Password</CardTitle>
+          <CardDescription>Enter your email to receive a reset link</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <PasswordResetRequestForm />
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default PasswordResetRequest;

--- a/src/pages/UpdatePassword.tsx
+++ b/src/pages/UpdatePassword.tsx
@@ -1,0 +1,20 @@
+import UpdatePasswordForm from "@/components/auth/UpdatePasswordForm";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+
+const UpdatePassword = () => {
+  return (
+    <div className="container max-w-md mx-auto px-4 py-16">
+      <Card className="w-full">
+        <CardHeader className="space-y-1 text-center">
+          <CardTitle className="text-2xl font-bold">Set New Password</CardTitle>
+          <CardDescription>Enter a new password for your account</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <UpdatePasswordForm />
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default UpdatePassword;


### PR DESCRIPTION
## Summary
- create form component for requesting a password reset email
- add form to update the password after the email link
- link to the request page from login
- register new password reset routes

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68687f2e46d483238a829f1a3f71a370