### PR TITLE
Add Supabase shopping analytics tables and hooks

### DIFF
--- a/src/hooks/use-shopping-analytics.ts
+++ b/src/hooks/use-shopping-analytics.ts
@@ -27,20 +27,70 @@ export function useShoppingAnalytics() {
     if (!user) return;
 
     try {
-      console.log('Tracking product interaction:', data);
-      // For now, just log the interaction
-      // TODO: Implement actual database tracking when tables are ready
+      // Insert interaction record
+      await supabase.from('product_interactions').insert({
+        user_id: user.id,
+        product_id: data.productId,
+        interaction_type: data.interactionType,
+        duration_seconds: data.durationSeconds || 0,
+        context_data: data.contextData || {}
+      });
+
+      // Record product view separately
+      if (data.interactionType === 'view') {
+        await supabase.from('product_views').insert({
+          user_id: user.id,
+          product_id: data.productId,
+          duration_seconds: data.durationSeconds || 0,
+          category: data.contextData?.category,
+          price: data.contextData?.price,
+          region: data.contextData?.region,
+          context_data: data.contextData || {}
+        });
+      }
+
+      // Update session totals
+      if (currentSession?.id) {
+        const updates: Partial<ShoppingSession> = {
+          totalInteractions: currentSession.totalInteractions + 1,
+          totalViews:
+            currentSession.totalViews + (data.interactionType === 'view' ? 1 : 0),
+          itemsPurchased:
+            currentSession.itemsPurchased +
+            (data.interactionType === 'purchase' ? 1 : 0),
+          totalSpent:
+            currentSession.totalSpent +
+            (data.interactionType === 'purchase'
+              ? data.contextData?.price || 0
+              : 0)
+        };
+
+        await supabase
+          .from('shopping_sessions')
+          .update(updates)
+          .eq('id', currentSession.id);
+
+        setCurrentSession(prev => (prev ? { ...prev, ...updates } : prev));
+      }
     } catch (error) {
       console.error('Error tracking product interaction:', error);
     }
-  }, [user]);
+  }, [user, currentSession]);
 
   const startShoppingSession = useCallback(async () => {
     if (!user || isTracking) return;
 
     try {
-      console.log('Starting shopping session for user:', user.id);
+      const { data, error } = await supabase
+        .from('shopping_sessions')
+        .insert({ user_id: user.id })
+        .select()
+        .single();
+
+      if (error) throw error;
+
       setCurrentSession({
+        id: data.id,
         totalViews: 0,
         totalInteractions: 0,
         itemsPurchased: 0,
@@ -56,7 +106,11 @@ export function useShoppingAnalytics() {
     if (!user || !currentSession || !isTracking) return;
 
     try {
-      console.log('Ending shopping session:', currentSession);
+      await supabase
+        .from('shopping_sessions')
+        .update({ session_end: new Date().toISOString() })
+        .eq('id', currentSession.id);
+
       setCurrentSession(null);
       setIsTracking(false);
     } catch (error) {
@@ -64,10 +118,54 @@ export function useShoppingAnalytics() {
     }
   }, [user, currentSession, isTracking]);
 
+  const fetchSessions = useCallback(async () => {
+    if (!user) return [];
+
+    const { data, error } = await supabase
+      .from('shopping_sessions')
+      .select('*')
+      .eq('user_id', user.id)
+      .order('session_start', { ascending: false });
+
+    if (error) {
+      console.error('Error fetching sessions:', error);
+      return [];
+    }
+
+    return data || [];
+  }, [user]);
+
+  const fetchSessionSummary = useCallback(async () => {
+    if (!user) return null;
+
+    const { data, error } = await supabase
+      .from('shopping_sessions')
+      .select('total_views, total_interactions, items_purchased, total_spent')
+      .eq('user_id', user.id);
+
+    if (error) {
+      console.error('Error fetching session summary:', error);
+      return null;
+    }
+
+    return (data || []).reduce(
+      (acc, cur) => ({
+        total_views: acc.total_views + (cur.total_views || 0),
+        total_interactions:
+          acc.total_interactions + (cur.total_interactions || 0),
+        items_purchased: acc.items_purchased + (cur.items_purchased || 0),
+        total_spent: acc.total_spent + (parseFloat(cur.total_spent as any) || 0)
+      }),
+      { total_views: 0, total_interactions: 0, items_purchased: 0, total_spent: 0 }
+    );
+  }, [user]);
+
   return {
     trackProductInteraction,
     startShoppingSession,
     endShoppingSession,
+    fetchSessions,
+    fetchSessionSummary,
     currentSession,
     isTracking
   };

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -3870,6 +3870,114 @@ export type Database = {
         }
         Relationships: []
       }
+      product_views: {
+        Row: {
+          id: string
+          user_id: string
+          product_id: string
+          view_start: string | null
+          view_end: string | null
+          duration_seconds: number | null
+          category: string | null
+          price: number | null
+          region: string | null
+          context_data: Json | null
+          created_at: string | null
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          product_id: string
+          view_start?: string | null
+          view_end?: string | null
+          duration_seconds?: number | null
+          category?: string | null
+          price?: number | null
+          region?: string | null
+          context_data?: Json | null
+          created_at?: string | null
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          product_id?: string
+          view_start?: string | null
+          view_end?: string | null
+          duration_seconds?: number | null
+          category?: string | null
+          price?: number | null
+          region?: string | null
+          context_data?: Json | null
+          created_at?: string | null
+        }
+        Relationships: []
+      }
+      product_interactions: {
+        Row: {
+          id: string
+          user_id: string
+          product_id: string
+          interaction_type: string
+          duration_seconds: number | null
+          context_data: Json | null
+          created_at: string | null
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          product_id: string
+          interaction_type: string
+          duration_seconds?: number | null
+          context_data?: Json | null
+          created_at?: string | null
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          product_id?: string
+          interaction_type?: string
+          duration_seconds?: number | null
+          context_data?: Json | null
+          created_at?: string | null
+        }
+        Relationships: []
+      }
+      shopping_sessions: {
+        Row: {
+          id: string
+          user_id: string | null
+          session_start: string | null
+          session_end: string | null
+          total_views: number | null
+          total_interactions: number | null
+          items_purchased: number | null
+          total_spent: number | null
+          context_data: Json | null
+        }
+        Insert: {
+          id?: string
+          user_id?: string | null
+          session_start?: string | null
+          session_end?: string | null
+          total_views?: number | null
+          total_interactions?: number | null
+          items_purchased?: number | null
+          total_spent?: number | null
+          context_data?: Json | null
+        }
+        Update: {
+          id?: string
+          user_id?: string | null
+          session_start?: string | null
+          session_end?: string | null
+          total_views?: number | null
+          total_interactions?: number | null
+          items_purchased?: number | null
+          total_spent?: number | null
+          context_data?: Json | null
+        }
+        Relationships: []
+      }
       user_social_profiles: {
         Row: {
           avatar_url: string | null

--- a/supabase/migrations/20250705013454-add-product-views.sql
+++ b/supabase/migrations/20250705013454-add-product-views.sql
@@ -1,0 +1,29 @@
+-- Create product_views table for tracking product page views
+CREATE TABLE public.product_views (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    product_id TEXT NOT NULL,
+    view_start TIMESTAMP WITH TIME ZONE DEFAULT now(),
+    view_end TIMESTAMP WITH TIME ZONE,
+    duration_seconds INTEGER DEFAULT 0,
+    category TEXT,
+    price DECIMAL(10,2),
+    region TEXT,
+    context_data JSONB DEFAULT '{}'::jsonb,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT now()
+);
+
+-- Indexes for fast querying
+CREATE INDEX idx_product_views_user_id ON public.product_views(user_id);
+CREATE INDEX idx_product_views_product_id ON public.product_views(product_id);
+CREATE INDEX idx_product_views_created_at ON public.product_views(created_at);
+
+-- Enable Row Level Security
+ALTER TABLE public.product_views ENABLE ROW LEVEL SECURITY;
+
+-- Policies
+CREATE POLICY "Users can view their own product views" ON public.product_views
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert their own product views" ON public.product_views
+  FOR INSERT WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- create new `product_views` table migration for Supabase
- update analytics hooks to write to Supabase instead of console logging
- update shopping behavior hook to persist events via Supabase
- extend Supabase type definitions for new tables

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_6868809647dc8323b4866569daac7880