### PR TITLE
Connect storage data to Supabase

### DIFF
--- a/src/components/wheels/storage/useStorageData.ts
+++ b/src/components/wheels/storage/useStorageData.ts
@@ -1,6 +1,7 @@
 
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/context/AuthContext';
+import { supabase } from '@/integrations/supabase/client';
 
 interface StorageItem {
   id: string;
@@ -25,62 +26,145 @@ export function useStorageData() {
   });
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    const loadStorageData = async () => {
-      if (!isAuthenticated || !user) {
-        setLoading(false);
-        return;
-      }
+  const loadStorageData = async () => {
+    if (!isAuthenticated || !user) {
+      setLoading(false);
+      return;
+    }
 
       try {
-        // Mock data for now - replace with actual API calls
-        const mockData: StorageData = {
-          items: [
-            { id: '1', name: 'Rice', location: 'Pantry', category: 'Food', quantity: 2 },
-            { id: '2', name: 'Spices Set', location: 'Upper Cabinet', category: 'Food', quantity: 1 },
-            { id: '3', name: 'Towels', location: 'Bathroom Cabinet', category: 'Linens', quantity: 4 },
-            { id: '4', name: 'Tools', location: 'External Left Bay', category: 'Tools', quantity: 1 }
-          ],
-          categories: ['Food', 'Linens', 'Tools', 'Clothing'],
-          locations: ['Pantry', 'Upper Cabinet', 'Bathroom Cabinet', 'External Left Bay', 'External Right Bay']
-        };
+        const userId = user.id;
 
-        setStorageData(mockData);
+        const [itemsRes, catRes, locRes] = await Promise.all([
+          supabase.from('storage_items').select('*').eq('user_id', userId),
+          supabase.from('storage_categories').select('*').eq('user_id', userId),
+          supabase.from('storage_locations').select('*').eq('user_id', userId)
+        ]);
+
+        if (itemsRes.error) throw itemsRes.error;
+        if (catRes.error) throw catRes.error;
+        if (locRes.error) throw locRes.error;
+
+        const categoriesMap = new Map((catRes.data || []).map(c => [c.id, c.name]));
+        const locationsMap = new Map((locRes.data || []).map(l => [l.id, l.name]));
+
+        const items: StorageItem[] = (itemsRes.data || []).map(i => ({
+          id: i.id,
+          name: i.name,
+          quantity: i.quantity || 0,
+          category: categoriesMap.get(i.category_id) || '',
+          location: locationsMap.get(i.location_id) || ''
+        }));
+
+        setStorageData({
+          items,
+          categories: Array.from(categoriesMap.values()),
+          locations: Array.from(locationsMap.values())
+        });
       } catch (error) {
         console.error('Error loading storage data:', error);
       } finally {
         setLoading(false);
       }
-    };
+  };
 
+  useEffect(() => {
     loadStorageData();
   }, [isAuthenticated, user]);
 
+  const getCategoryId = async (name: string) => {
+    if (!user) return null;
+    const { data, error } = await supabase
+      .from('storage_categories')
+      .select('id')
+      .eq('user_id', user.id)
+      .eq('name', name)
+      .single();
+    if (error || !data) {
+      const { data: inserted, error: insertError } = await supabase
+        .from('storage_categories')
+        .insert({ user_id: user.id, name })
+        .select()
+        .single();
+      if (insertError || !inserted) throw insertError;
+      return inserted.id;
+    }
+    return data.id;
+  };
+
+  const getLocationId = async (name: string) => {
+    if (!user) return null;
+    const { data, error } = await supabase
+      .from('storage_locations')
+      .select('id')
+      .eq('user_id', user.id)
+      .eq('name', name)
+      .single();
+    if (error || !data) {
+      const { data: inserted, error: insertError } = await supabase
+        .from('storage_locations')
+        .insert({ user_id: user.id, name })
+        .select()
+        .single();
+      if (insertError || !inserted) throw insertError;
+      return inserted.id;
+    }
+    return data.id;
+  };
+
   const addItem = async (item: Omit<StorageItem, 'id'>) => {
-    const newItem = {
-      ...item,
-      id: Date.now().toString()
-    };
-    setStorageData(prev => ({
-      ...prev,
-      items: [...prev.items, newItem]
-    }));
+    if (!user) return;
+    try {
+      const category_id = await getCategoryId(item.category);
+      const location_id = await getLocationId(item.location);
+      await supabase.from('storage_items').insert({
+        user_id: user.id,
+        name: item.name,
+        quantity: item.quantity,
+        category_id,
+        location_id
+      });
+      await loadStorageData();
+    } catch (error) {
+      console.error('Add item failed:', error);
+    }
   };
 
   const updateItem = async (id: string, updates: Partial<StorageItem>) => {
-    setStorageData(prev => ({
-      ...prev,
-      items: prev.items.map(item => 
-        item.id === id ? { ...item, ...updates } : item
-      )
-    }));
+    if (!user) return;
+    try {
+      const payload: any = {};
+      if (updates.name !== undefined) payload.name = updates.name;
+      if (updates.quantity !== undefined) payload.quantity = updates.quantity;
+      if (updates.category !== undefined) {
+        payload.category_id = await getCategoryId(updates.category);
+      }
+      if (updates.location !== undefined) {
+        payload.location_id = await getLocationId(updates.location);
+      }
+      await supabase
+        .from('storage_items')
+        .update(payload)
+        .eq('id', id)
+        .eq('user_id', user.id);
+      await loadStorageData();
+    } catch (error) {
+      console.error('Update item failed:', error);
+    }
   };
 
   const deleteItem = async (id: string) => {
-    setStorageData(prev => ({
-      ...prev,
-      items: prev.items.filter(item => item.id !== id)
-    }));
+    if (!user) return;
+    try {
+      await supabase
+        .from('storage_items')
+        .delete()
+        .eq('id', id)
+        .eq('user_id', user.id);
+      await loadStorageData();
+    } catch (error) {
+      console.error('Delete item failed:', error);
+    }
   };
 
   return {

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -4370,6 +4370,94 @@ export type Database = {
         }
         Relationships: []
       }
+
+      storage_categories: {
+        Row: {
+          id: string
+          user_id: string
+          name: string
+          created_at: string | null
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          name: string
+          created_at?: string | null
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          name?: string
+          created_at?: string | null
+        }
+        Relationships: []
+      },
+      storage_locations: {
+        Row: {
+          id: string
+          user_id: string
+          name: string
+          created_at: string | null
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          name: string
+          created_at?: string | null
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          name?: string
+          created_at?: string | null
+        }
+        Relationships: []
+      },
+      storage_items: {
+        Row: {
+          id: string
+          user_id: string
+          name: string
+          category_id: string | null
+          location_id: string | null
+          quantity: number | null
+          created_at: string | null
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          name: string
+          category_id?: string | null
+          location_id?: string | null
+          quantity?: number | null
+          created_at?: string | null
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          name?: string
+          category_id?: string | null
+          location_id?: string | null
+          quantity?: number | null
+          created_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "storage_items_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "storage_categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "storage_items_location_id_fkey"
+            columns: ["location_id"]
+            isOneToOne: false
+            referencedRelation: "storage_locations"
+            referencedColumns: ["id"]
+          },
+        ]
+      },
     }
     Functions: {
       bootstrap_admin_user: {

--- a/supabase/migrations/20250705150000-create-storage-tables.sql
+++ b/supabase/migrations/20250705150000-create-storage-tables.sql
@@ -1,0 +1,49 @@
+-- Create storage_categories table
+CREATE TABLE public.storage_categories (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+    name text NOT NULL,
+    created_at timestamp with time zone DEFAULT now()
+);
+
+ALTER TABLE public.storage_categories ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users manage own categories" ON public.storage_categories
+    FOR ALL USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+-- Create storage_locations table
+CREATE TABLE public.storage_locations (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+    name text NOT NULL,
+    created_at timestamp with time zone DEFAULT now()
+);
+
+ALTER TABLE public.storage_locations ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users manage own locations" ON public.storage_locations
+    FOR ALL USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+-- Create storage_items table
+CREATE TABLE public.storage_items (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+    name text NOT NULL,
+    category_id uuid REFERENCES public.storage_categories(id),
+    location_id uuid REFERENCES public.storage_locations(id),
+    quantity integer DEFAULT 1,
+    created_at timestamp with time zone DEFAULT now()
+);
+
+ALTER TABLE public.storage_items ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users manage own storage items" ON public.storage_items
+    FOR ALL USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+-- Indexes
+CREATE INDEX idx_storage_categories_user_id ON public.storage_categories(user_id);
+CREATE INDEX idx_storage_locations_user_id ON public.storage_locations(user_id);
+CREATE INDEX idx_storage_items_user_id ON public.storage_items(user_id);


### PR DESCRIPTION
## Summary
- add storage tables via new migration
- update Supabase types with new tables
- replace mock storage hook logic with Supabase queries

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_686892998d1c8323bfe46efe55dd103f