### PR TITLE
Implement Supabase-backed settings forms

### DIFF
--- a/src/components/settings/DisplaySettings.tsx
+++ b/src/components/settings/DisplaySettings.tsx
@@ -1,15 +1,115 @@
 
-import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Monitor } from 'lucide-react';
+import { useUserSettings } from '@/hooks/useUserSettings';
 
 export const DisplaySettings = () => {
+  const { settings, updateSettings, updating } = useUserSettings();
+
+  if (!settings) return null;
+
+  const handleToggle = (key: keyof typeof settings.display_preferences) => {
+    updateSettings({
+      display_preferences: {
+        ...settings.display_preferences,
+        [key]: !settings.display_preferences[key],
+      },
+    });
+  };
+
+  const handleSelect = (key: keyof typeof settings.display_preferences, value: string) => {
+    updateSettings({
+      display_preferences: {
+        ...settings.display_preferences,
+        [key]: value,
+      },
+    });
+  };
+
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Display Settings</CardTitle>
+        <CardTitle className="flex items-center gap-2">
+          <Monitor className="h-5 w-5" />
+          Display
+        </CardTitle>
       </CardHeader>
-      <CardContent>
-        <p className="text-gray-600">Display settings coming soon...</p>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label>Theme</Label>
+          <Select
+            value={settings.display_preferences.theme}
+            onValueChange={(val) => handleSelect('theme', val)}
+            disabled={updating}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="light">Light</SelectItem>
+              <SelectItem value="dark">Dark</SelectItem>
+              <SelectItem value="system">System</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label>Font Size</Label>
+          <Select
+            value={settings.display_preferences.font_size}
+            onValueChange={(val) => handleSelect('font_size', val)}
+            disabled={updating}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="small">Small</SelectItem>
+              <SelectItem value="medium">Medium</SelectItem>
+              <SelectItem value="large">Large</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        {(
+          [
+            ['high_contrast', 'High Contrast'],
+            ['reduced_motion', 'Reduced Motion'],
+          ] as [keyof typeof settings.display_preferences, string][]
+        ).map(([key, label]) => (
+          <div key={key} className="flex items-center justify-between">
+            <Label htmlFor={key} className="text-sm font-medium">
+              {label}
+            </Label>
+            <Switch
+              id={key}
+              checked={settings.display_preferences[key] as boolean}
+              onCheckedChange={() => handleToggle(key)}
+              disabled={updating}
+            />
+          </div>
+        ))}
+
+        <div className="space-y-2">
+          <Label>Language</Label>
+          <Select
+            value={settings.display_preferences.language}
+            onValueChange={(val) => handleSelect('language', val)}
+            disabled={updating}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="en">English</SelectItem>
+              <SelectItem value="es">Spanish</SelectItem>
+              <SelectItem value="fr">French</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
       </CardContent>
     </Card>
   );

--- a/src/components/settings/IntegrationSettings.tsx
+++ b/src/components/settings/IntegrationSettings.tsx
@@ -1,15 +1,51 @@
 
-import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import { Network } from 'lucide-react';
+import { useUserSettings } from '@/hooks/useUserSettings';
 
 export const IntegrationSettings = () => {
+  const { settings, updateSettings, updating } = useUserSettings();
+
+  if (!settings) return null;
+
+  const handleToggle = (key: keyof NonNullable<typeof settings.integration_preferences>) => {
+    updateSettings({
+      integration_preferences: {
+        ...settings.integration_preferences,
+        [key]: !settings.integration_preferences?.[key],
+      },
+    });
+  };
+
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Integration Settings</CardTitle>
+        <CardTitle className="flex items-center gap-2">
+          <Network className="h-5 w-5" />
+          Integrations
+        </CardTitle>
       </CardHeader>
-      <CardContent>
-        <p className="text-gray-600">Integration settings coming soon...</p>
+      <CardContent className="space-y-4">
+        <div className="flex items-center justify-between">
+          <Label htmlFor="shop-travel">Shop & Travel Integration</Label>
+          <Switch
+            id="shop-travel"
+            checked={settings.integration_preferences?.shop_travel_integration ?? false}
+            onCheckedChange={() => handleToggle('shop_travel_integration')}
+            disabled={updating}
+          />
+        </div>
+        <div className="flex items-center justify-between">
+          <Label htmlFor="auto-storage">Auto-add Purchases to Storage</Label>
+          <Switch
+            id="auto-storage"
+            checked={settings.integration_preferences?.auto_add_purchases_to_storage ?? false}
+            onCheckedChange={() => handleToggle('auto_add_purchases_to_storage')}
+            disabled={updating}
+          />
+        </div>
       </CardContent>
     </Card>
   );

--- a/src/components/settings/NotificationSettings.tsx
+++ b/src/components/settings/NotificationSettings.tsx
@@ -1,15 +1,55 @@
 
-import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import { Bell } from 'lucide-react';
+import { useUserSettings } from '@/hooks/useUserSettings';
 
 export const NotificationSettings = () => {
+  const { settings, updateSettings, updating } = useUserSettings();
+
+  if (!settings) return null;
+
+  const handleToggle = (key: keyof typeof settings.notification_preferences) => {
+    updateSettings({
+      notification_preferences: {
+        ...settings.notification_preferences,
+        [key]: !settings.notification_preferences[key],
+      },
+    });
+  };
+
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Notification Settings</CardTitle>
+        <CardTitle className="flex items-center gap-2">
+          <Bell className="h-5 w-5" />
+          Notifications
+        </CardTitle>
       </CardHeader>
-      <CardContent>
-        <p className="text-gray-600">Notification settings coming soon...</p>
+      <CardContent className="space-y-4">
+        {(
+          [
+            ['email_notifications', 'Email Notifications'],
+            ['push_notifications', 'Push Notifications'],
+            ['marketing_emails', 'Marketing Emails'],
+            ['trip_reminders', 'Trip Reminders'],
+            ['maintenance_alerts', 'Maintenance Alerts'],
+            ['weather_warnings', 'Weather Warnings'],
+          ] as [keyof typeof settings.notification_preferences, string][]
+        ).map(([key, label]) => (
+          <div key={key} className="flex items-center justify-between">
+            <Label htmlFor={key} className="text-sm font-medium">
+              {label}
+            </Label>
+            <Switch
+              id={key}
+              checked={settings.notification_preferences[key]}
+              onCheckedChange={() => handleToggle(key)}
+              disabled={updating}
+            />
+          </div>
+        ))}
       </CardContent>
     </Card>
   );

--- a/src/components/settings/PrivacySettings.tsx
+++ b/src/components/settings/PrivacySettings.tsx
@@ -1,15 +1,80 @@
 
-import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Shield } from 'lucide-react';
+import { useUserSettings } from '@/hooks/useUserSettings';
 
 export const PrivacySettings = () => {
+  const { settings, updateSettings, updating } = useUserSettings();
+
+  if (!settings) return null;
+
+  const handleToggle = (key: keyof typeof settings.privacy_preferences) => {
+    updateSettings({
+      privacy_preferences: {
+        ...settings.privacy_preferences,
+        [key]: !settings.privacy_preferences[key],
+      },
+    });
+  };
+
+  const handleSelect = (value: string) => {
+    updateSettings({
+      privacy_preferences: {
+        ...settings.privacy_preferences,
+        profile_visibility: value,
+      },
+    });
+  };
+
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Privacy Settings</CardTitle>
+        <CardTitle className="flex items-center gap-2">
+          <Shield className="h-5 w-5" />
+          Privacy
+        </CardTitle>
       </CardHeader>
-      <CardContent>
-        <p className="text-gray-600">Privacy settings coming soon...</p>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label>Profile Visibility</Label>
+          <Select
+            value={settings.privacy_preferences.profile_visibility}
+            onValueChange={handleSelect}
+            disabled={updating}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="public">Public</SelectItem>
+              <SelectItem value="friends">Friends Only</SelectItem>
+              <SelectItem value="private">Private</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        {(
+          [
+            ['location_sharing', 'Location Sharing'],
+            ['activity_tracking', 'Activity Tracking'],
+            ['data_collection', 'Data Collection'],
+          ] as [keyof typeof settings.privacy_preferences, string][]
+        ).map(([key, label]) => (
+          <div key={key} className="flex items-center justify-between">
+            <Label htmlFor={key} className="text-sm font-medium">
+              {label}
+            </Label>
+            <Switch
+              id={key}
+              checked={settings.privacy_preferences[key]}
+              onCheckedChange={() => handleToggle(key)}
+              disabled={updating}
+            />
+          </div>
+        ))}
       </CardContent>
     </Card>
   );

--- a/src/components/settings/ProfileSettings.tsx
+++ b/src/components/settings/ProfileSettings.tsx
@@ -1,15 +1,90 @@
 
-import React from 'react';
+import { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { User } from 'lucide-react';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/context/AuthContext';
+import { toast } from 'sonner';
 
 export const ProfileSettings = () => {
+  const { user } = useAuth();
+  const [fullName, setFullName] = useState('');
+  const [nickname, setNickname] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    const loadProfile = async () => {
+      if (!user) return;
+      setLoading(true);
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('full_name,nickname')
+        .eq('user_id', user.id)
+        .single();
+      if (!error && data) {
+        setFullName(data.full_name || '');
+        setNickname(data.nickname || '');
+      }
+      setLoading(false);
+    };
+    loadProfile();
+  }, [user]);
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!user) return;
+    setSaving(true);
+    try {
+      const { error } = await supabase
+        .from('profiles')
+        .update({ full_name: fullName, nickname })
+        .eq('user_id', user.id);
+      if (error) throw error;
+      toast.success('Profile updated');
+    } catch (err) {
+      console.error('Error updating profile:', err);
+      toast.error('Failed to update profile');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!user || loading) return null;
+
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Profile Settings</CardTitle>
+        <CardTitle className="flex items-center gap-2">
+          <User className="h-5 w-5" />
+          Profile
+        </CardTitle>
       </CardHeader>
       <CardContent>
-        <p className="text-gray-600">Profile settings coming soon...</p>
+        <form onSubmit={handleSave} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="full-name">Full Name</Label>
+            <Input
+              id="full-name"
+              value={fullName}
+              onChange={(e) => setFullName(e.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="nickname">Nickname</Label>
+            <Input
+              id="nickname"
+              value={nickname}
+              onChange={(e) => setNickname(e.target.value)}
+            />
+          </div>
+          <Button type="submit" disabled={saving} className="mt-2">
+            {saving ? 'Saving...' : 'Save'}
+          </Button>
+        </form>
       </CardContent>
     </Card>
   );

--- a/src/components/settings/RegionalSettings.tsx
+++ b/src/components/settings/RegionalSettings.tsx
@@ -1,15 +1,103 @@
 
-import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Globe } from 'lucide-react';
+import { useUserSettings } from '@/hooks/useUserSettings';
 
 export const RegionalSettings = () => {
+  const { settings, updateSettings, updating } = useUserSettings();
+
+  if (!settings) return null;
+
+  const handleSelect = (key: keyof typeof settings.regional_preferences, value: string) => {
+    updateSettings({
+      regional_preferences: {
+        ...settings.regional_preferences,
+        [key]: value,
+      },
+    });
+  };
+
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Regional Settings</CardTitle>
+        <CardTitle className="flex items-center gap-2">
+          <Globe className="h-5 w-5" />
+          Regional
+        </CardTitle>
       </CardHeader>
-      <CardContent>
-        <p className="text-gray-600">Regional settings coming soon...</p>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label>Currency</Label>
+          <Select
+            value={settings.regional_preferences.currency}
+            onValueChange={(val) => handleSelect('currency', val)}
+            disabled={updating}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="USD">USD</SelectItem>
+              <SelectItem value="EUR">EUR</SelectItem>
+              <SelectItem value="GBP">GBP</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label>Units</Label>
+          <Select
+            value={settings.regional_preferences.units}
+            onValueChange={(val) => handleSelect('units', val)}
+            disabled={updating}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="metric">Metric</SelectItem>
+              <SelectItem value="imperial">Imperial</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label>Timezone</Label>
+          <Select
+            value={settings.regional_preferences.timezone}
+            onValueChange={(val) => handleSelect('timezone', val)}
+            disabled={updating}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="auto">Auto</SelectItem>
+              <SelectItem value="America/New_York">America/New_York</SelectItem>
+              <SelectItem value="Europe/London">Europe/London</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label>Date Format</Label>
+          <Select
+            value={settings.regional_preferences.date_format}
+            onValueChange={(val) => handleSelect('date_format', val)}
+            disabled={updating}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="MM/DD/YYYY">MM/DD/YYYY</SelectItem>
+              <SelectItem value="DD/MM/YYYY">DD/MM/YYYY</SelectItem>
+              <SelectItem value="YYYY-MM-DD">YYYY-MM-DD</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
       </CardContent>
     </Card>
   );

--- a/src/hooks/useUserSettings.ts
+++ b/src/hooks/useUserSettings.ts
@@ -1,7 +1,37 @@
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/context/AuthContext';
+import { toast } from 'sonner';
 
 interface UserSettings {
+  notification_preferences: {
+    email_notifications: boolean;
+    push_notifications: boolean;
+    marketing_emails: boolean;
+    trip_reminders: boolean;
+    maintenance_alerts: boolean;
+    weather_warnings: boolean;
+  };
+  privacy_preferences: {
+    profile_visibility: string;
+    location_sharing: boolean;
+    activity_tracking: boolean;
+    data_collection: boolean;
+  };
+  display_preferences: {
+    theme: string;
+    font_size: string;
+    high_contrast: boolean;
+    reduced_motion: boolean;
+    language: string;
+  };
+  regional_preferences: {
+    currency: string;
+    units: string;
+    timezone: string;
+    date_format: string;
+  };
   pam_preferences: {
     voice_enabled: boolean;
     proactive_suggestions: boolean;
@@ -16,29 +46,69 @@ interface UserSettings {
 }
 
 export const useUserSettings = () => {
-  const [settings, setSettings] = useState<UserSettings>({
-    pam_preferences: {
-      voice_enabled: true,
-      proactive_suggestions: false,
-      response_style: 'balanced',
-      expertise_level: 'intermediate',
-      knowledge_sources: true,
-    },
-    integration_preferences: {
-      shop_travel_integration: false,
-      auto_add_purchases_to_storage: false,
-    },
-  });
+  const { user } = useAuth();
+  const [settings, setSettings] = useState<UserSettings | null>(null);
   const [updating, setUpdating] = useState(false);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  const fetchSettings = async () => {
+    if (!user) return;
+    setLoading(true);
+    try {
+      const { data, error } = await supabase
+        .from('user_settings')
+        .select('*')
+        .eq('user_id', user.id)
+        .single();
+
+      if (error) {
+        if (error.code === 'PGRST116') {
+          const { data: created, error: insertError } = await supabase
+            .from('user_settings')
+            .insert({ user_id: user.id })
+            .select()
+            .single();
+          if (insertError) throw insertError;
+          setSettings(created as UserSettings);
+        } else {
+          throw error;
+        }
+      } else {
+        setSettings(data as UserSettings);
+      }
+    } catch (err) {
+      console.error('Error loading settings:', err);
+      toast.error('Failed to load settings');
+    } finally {
+      setLoading(false);
+    }
+  };
 
   const updateSettings = async (newSettings: Partial<UserSettings>) => {
+    if (!user) return;
     setUpdating(true);
-    // Mock update
-    await new Promise(resolve => setTimeout(resolve, 500));
-    setSettings(prev => ({ ...prev, ...newSettings }));
-    setUpdating(false);
+    try {
+      const { data, error } = await supabase
+        .from('user_settings')
+        .update(newSettings)
+        .eq('user_id', user.id)
+        .select()
+        .single();
+
+      if (error) throw error;
+      if (data) setSettings(data as UserSettings);
+      toast.success('Settings updated');
+    } catch (err) {
+      console.error('Error updating settings:', err);
+      toast.error('Failed to update settings');
+    } finally {
+      setUpdating(false);
+    }
   };
+
+  useEffect(() => {
+    fetchSettings();
+  }, [user?.id]);
 
   return {
     settings,


### PR DESCRIPTION
## Summary
- connect useUserSettings hook to Supabase
- implement profile editing form
- add notification, privacy, display, regional, and integration settings forms

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686894c7e8008323aca946c0141ca2b9