### PR TITLE
Add support ticket system

### DIFF
--- a/backend/app/api/v1/support.py
+++ b/backend/app/api/v1/support.py
@@ -1,0 +1,68 @@
+from fastapi import APIRouter, HTTPException, Depends
+from pydantic import BaseModel
+from datetime import datetime
+
+from app.services.database import get_database_service
+
+router = APIRouter()
+
+class TicketCreate(BaseModel):
+    user_id: str
+    subject: str
+    message: str
+
+class TicketStatusUpdate(BaseModel):
+    status: str
+
+@router.post("/support/tickets")
+async def create_ticket(ticket: TicketCreate):
+    """Create a new support ticket"""
+    db_service = await get_database_service()
+    supabase = db_service.get_client()
+
+    try:
+        result = supabase.table("support_tickets").insert({
+            "user_id": ticket.user_id,
+            "subject": ticket.subject,
+            "message": ticket.message,
+            "status": "open",
+            "created_at": datetime.utcnow().isoformat(),
+            "updated_at": datetime.utcnow().isoformat(),
+        }).execute()
+        if not result.data:
+            raise HTTPException(status_code=400, detail="Failed to create ticket")
+        return {"id": result.data[0]["id"], "status": "open"}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.get("/support/tickets")
+async def list_tickets(status: str = "open"):
+    """List tickets filtered by status"""
+    db_service = await get_database_service()
+    supabase = db_service.get_client()
+
+    try:
+        query = supabase.table("support_tickets").select("*").order("created_at", desc=True)
+        if status:
+            query = query.eq("status", status)
+        result = query.execute()
+        return result.data or []
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.put("/support/tickets/{ticket_id}")
+async def update_ticket_status(ticket_id: str, update: TicketStatusUpdate):
+    """Update ticket status"""
+    db_service = await get_database_service()
+    supabase = db_service.get_client()
+
+    try:
+        result = supabase.table("support_tickets").update({
+            "status": update.status,
+            "updated_at": datetime.utcnow().isoformat(),
+        }).eq("id", ticket_id).execute()
+        if result.error:
+            raise HTTPException(status_code=400, detail="Failed to update ticket")
+        return {"id": ticket_id, "status": update.status}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,7 +25,7 @@ from app.services.monitoring_service import monitoring_service
 from app.services.sentry_service import sentry_service
 
 # Import API routers
-from app.api.v1 import health, chat, wins, wheels, social, monitoring, pam, auth, subscription
+from app.api.v1 import health, chat, wins, wheels, social, monitoring, pam, auth, subscription, support
 
 logger = setup_logging()
 
@@ -121,6 +121,7 @@ app.include_router(social.router, prefix="/api", tags=["Social"])
 app.include_router(pam.router, prefix="/api", tags=["PAM"])
 app.include_router(auth.router, prefix="/api/auth", tags=["Authentication"])
 app.include_router(subscription.router, prefix="/api/v1", tags=["Subscription"])
+app.include_router(support.router, prefix="/api", tags=["Support"])
 
 # Global exception handler with monitoring
 @app.exception_handler(Exception)

--- a/src/components/admin/AdminContent.tsx
+++ b/src/components/admin/AdminContent.tsx
@@ -7,6 +7,7 @@ import ContentModeration from './ContentModeration';
 import ReportsAnalytics from './ReportsAnalytics';
 import PAMAnalyticsDashboard from './PAMAnalyticsDashboard';
 import ShopManagement from './ShopManagement';
+import SupportTickets from './SupportTickets';
 import Settings from './Settings';
 
 interface AdminContentProps {
@@ -31,12 +32,7 @@ const AdminContent: React.FC<AdminContentProps> = ({ activeSection }) => {
       case 'Shop Management':
         return <ShopManagement />;
       case 'Support Tickets':
-        return (
-          <div className="p-6">
-            <h2 className="text-2xl font-bold mb-4">Support Tickets</h2>
-            <p className="text-gray-600">Support ticket features coming soon...</p>
-          </div>
-        );
+        return <SupportTickets />;
       case 'Settings':
         return <Settings />;
       default:

--- a/src/components/admin/SupportTickets.tsx
+++ b/src/components/admin/SupportTickets.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableHeader, TableBody, TableHead, TableRow, TableCell } from '@/components/ui/table';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { RefreshCw } from 'lucide-react';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+
+interface Ticket {
+  id: string;
+  user_id: string;
+  subject: string;
+  message: string;
+  status: string;
+  created_at: string;
+}
+
+const SupportTickets = () => {
+  const [tickets, setTickets] = useState<Ticket[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchTickets = async () => {
+    setLoading(true);
+    const { data, error } = await supabase
+      .from('support_tickets')
+      .select('*')
+      .not('status', 'eq', 'closed')
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      toast.error(`Failed to fetch tickets: ${error.message}`);
+    } else {
+      setTickets(data || []);
+    }
+    setLoading(false);
+  };
+
+  const updateStatus = async (ticketId: string, status: string) => {
+    const { error } = await supabase
+      .from('support_tickets')
+      .update({ status, updated_at: new Date().toISOString() })
+      .eq('id', ticketId);
+
+    if (error) {
+      toast.error(`Failed to update ticket: ${error.message}`);
+    } else {
+      toast.success('Ticket updated');
+      fetchTickets();
+    }
+  };
+
+  useEffect(() => {
+    fetchTickets();
+  }, []);
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Support Tickets</h1>
+          <p className="text-muted-foreground text-sm">Manage user support requests</p>
+        </div>
+        <Button onClick={fetchTickets} disabled={loading}>
+          <RefreshCw className={`h-4 w-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
+          Refresh
+        </Button>
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>Open Tickets ({tickets.length})</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="flex justify-center py-8">
+              <RefreshCw className="h-8 w-8 animate-spin text-gray-400" />
+            </div>
+          ) : tickets.length === 0 ? (
+            <div className="text-center py-8">
+              <p className="text-gray-500">No open tickets.</p>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Subject</TableHead>
+                    <TableHead>User</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Date</TableHead>
+                    <TableHead>Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {tickets.map((t) => (
+                    <TableRow key={t.id}>
+                      <TableCell>
+                        <div>
+                          <p className="font-medium">{t.subject}</p>
+                          <p className="text-sm text-gray-500 truncate max-w-xs">{t.message}</p>
+                        </div>
+                      </TableCell>
+                      <TableCell className="font-mono text-sm">{t.user_id.slice(0, 8)}...</TableCell>
+                      <TableCell>
+                        <Badge variant="outline">{t.status}</Badge>
+                      </TableCell>
+                      <TableCell>{new Date(t.created_at).toLocaleDateString()}</TableCell>
+                      <TableCell>
+                        <Select value={t.status} onValueChange={(val) => updateStatus(t.id, val)}>
+                          <SelectTrigger className="w-[120px] h-8">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="open">Open</SelectItem>
+                            <SelectItem value="in_progress">In Progress</SelectItem>
+                            <SelectItem value="closed">Closed</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default SupportTickets;

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -3279,6 +3279,7 @@ export type Database = {
           message: string
           status: string | null
           subject: string
+          updated_at: string | null
           user_id: string
         }
         Insert: {
@@ -3287,6 +3288,7 @@ export type Database = {
           message: string
           status?: string | null
           subject: string
+          updated_at?: string | null
           user_id: string
         }
         Update: {
@@ -3295,6 +3297,7 @@ export type Database = {
           message?: string
           status?: string | null
           subject?: string
+          updated_at?: string | null
           user_id?: string
         }
         Relationships: []

--- a/supabase/migrations/20250706001000-add-support-tickets.sql
+++ b/supabase/migrations/20250706001000-add-support-tickets.sql
@@ -1,0 +1,22 @@
+-- Create support_tickets table for help desk functionality
+CREATE TABLE public.support_tickets (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
+    subject text NOT NULL,
+    message text NOT NULL,
+    status text NOT NULL DEFAULT 'open',
+    created_at timestamp with time zone DEFAULT now(),
+    updated_at timestamp with time zone DEFAULT now()
+);
+
+ALTER TABLE public.support_tickets ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users manage own tickets" ON public.support_tickets
+    FOR ALL USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+CREATE INDEX idx_support_tickets_user_id ON public.support_tickets(user_id);
+
+CREATE TRIGGER update_support_tickets_updated_at
+    BEFORE UPDATE ON public.support_tickets
+    FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();


### PR DESCRIPTION
## Summary
- add migration and schema updates for `support_tickets`
- implement API routes under `/support/tickets`
- hook support router into backend app
- create `SupportTickets` admin component and show in admin content

## Testing
- `npm test` *(fails: vitest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: pytest_asyncio, httpx, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686899d2f21c832398629dc6359b03b0