### PR TITLE
Use env vars for Supabase client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,14 @@
 # Example environment configuration
 # Copy this file to .env and fill in your own values
 
+# Supabase configuration
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
+SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
+
+# Backend API
+VITE_BACKEND_URL=https://pam-backend.onrender.com
+
 # Mapbox public access token (should start with 'pk.')
 VITE_MAPBOX_TOKEN=pk.your_mapbox_token_here
 

--- a/.env.production
+++ b/.env.production
@@ -2,25 +2,25 @@
 # Copy this to .env and fill in your actual values
 
 # Database (Supabase)
-SUPABASE_URL=https://kycoklimpzkyrecbjecn.supabase.co
-SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imt5Y29rbGltcHpreXJlY2JqZWNuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDYyNTU4MDAsImV4cCI6MjA2MTgzMTgwMH0.nRZhYxImQ0rOlh0xZjHcdVq2Q2NY0v-9W3wciaxV2EA
-SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imt5Y29rbGltcHpreXJlY2JqZWNuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDYyNTU4MDAsImV4cCI6MjA2MTgzMTgwMH0.nRZhYxImQ0rOlh0xZjHcdVq2Q2NY0v-9W3wciaxV2EA
+SUPABASE_URL=
+SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
 
 # OpenAI
-OPENAI_API_KEY=your_openai_api_key_here
+OPENAI_API_KEY=
 
 # Redis (for caching and Celery)
-REDIS_URL=redis://localhost:6379
+REDIS_URL=
 
 # Sentry (error tracking)
-SENTRY_DSN=your_sentry_dsn_here
+SENTRY_DSN=
 
 # Application
 ENVIRONMENT=production
 DEBUG=False
-SECRET_KEY=your_secret_key_here
+SECRET_KEY=
 
 # CORS settings
 ALLOWED_ORIGINS=["https://yourdomain.com", "https://www.yourdomain.com"]
 VITE_BACKEND_URL=https://pam-backend.onrender.com
-VITE_MAPBOX_TOKEN=pk.eyJ1IjoidGhhYm9uZWwiLCJhIjoiY204d3lwMnhwMDBmdTJqb2JsdWgzdmZ2YyJ9.0wyj48txMJAJht1kYfyOdQ
+VITE_MAPBOX_TOKEN=

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -1,8 +1,8 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = 'https://kycoklimpzkyrecbjecn.supabase.co';
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imt5Y29rbGltcHpreXJlY2JqZWNuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDYyNTU4MDAsImV4cCI6MjA2MTgzMTgwMH0.nRZhYxImQ0rOlh0xZjHcdVq2Q2NY0v-9W3wciaxV2EA';
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
   console.error('Supabase environment variables are missing');


### PR DESCRIPTION
## Summary
- load Supabase URL and anon key from environment variables
- strip secrets from `.env.production`
- expand `.env.example` with required variables

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: dependency resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_68689cfd027c8323a6c99267002223b8