### PR TITLE
Implement Supabase personalized recommendations

### DIFF
--- a/supabase/migrations/20250706002000-personalized-recommendations.sql
+++ b/supabase/migrations/20250706002000-personalized-recommendations.sql
@@ -1,0 +1,21 @@
+-- Create RPC for fetching personalized recommendations
+CREATE OR REPLACE FUNCTION public.get_personalized_recommendations(
+  p_user_id uuid,
+  p_limit integer DEFAULT 9
+)
+RETURNS TABLE (
+  id uuid,
+  product_id text,
+  recommendation_type text,
+  confidence_score numeric,
+  context jsonb,
+  created_at timestamptz,
+  expires_at timestamptz
+) AS $$
+  SELECT id, product_id, recommendation_type, confidence_score, context, created_at, expires_at
+  FROM public.personalized_recommendations
+  WHERE user_id = p_user_id
+    AND expires_at > now()
+  ORDER BY confidence_score DESC, created_at DESC
+  LIMIT p_limit;
+$$ LANGUAGE SQL STABLE;


### PR DESCRIPTION
## Summary
- add RPC for fetching personalized recommendations
- fetch recommendations from Supabase in `usePersonalizedRecommendations`

## Testing
- `npm run type-check`
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: missing @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68689dd84e908323b951e9de116f5587