### PR TITLE
Add migration for calendar_events RLS

### DIFF
--- a/supabase/migrations/20250706235251-663beb4c-794c-4c4c-95d6-e41875886539.sql
+++ b/supabase/migrations/20250706235251-663beb4c-794c-4c4c-95d6-e41875886539.sql
@@ -1,0 +1,6 @@
+ALTER TABLE public.calendar_events ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users manage own calendar events"
+  ON public.calendar_events
+  FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- enable RLS on `calendar_events`
- add policy so users can only manage their own events

## Testing
- `npm test` *(fails: vitest not found)*
- `npx supabase db push` *(fails: cannot find project ref)*

------
https://chatgpt.com/codex/tasks/task_e_686b0c205dc48323a12f37e6056f0a6e