### PR TITLE
Add structured response model

### DIFF
--- a/backend/app/models/structured_responses.py
+++ b/backend/app/models/structured_responses.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel, validator
+
+class StructuredResponse(BaseModel):
+    answer_display: str
+    answer_speech: str
+    answer_ssml: str
+    ui_actions: list | None = []
+    memory_updates: dict | None = {}
+
+    @validator("answer_speech")
+    def max_70_words(cls, v):
+        assert len(v.split()) <= 70, "Speech too long"
+        return v


### PR DESCRIPTION
## Summary
- add `StructuredResponse` pydantic model

## Testing
- `python -m py_compile backend/app/models/structured_responses.py`
- `pytest -q` *(fails: ModuleNotFoundError: pytest_asyncio)*

------
https://chatgpt.com/codex/tasks/task_e_686b291bdd2c8323824154a1998eac14