### PR TITLE
Add PauterRouter Runnable

### DIFF
--- a/backend/app/services/pam/mcp/controllers/pauter_router.py
+++ b/backend/app/services/pam/mcp/controllers/pauter_router.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Optional
+
+from langchain_core.runnables import Runnable, RunnableConfig
+
+
+class PauterRouter(Runnable[str, Dict[str, Any]]):
+    """Simple heuristic router for PAM nodes."""
+
+    VALID_NODES = {"wheels", "wins", "social", "memory"}
+
+    def _route(self, text: str) -> Dict[str, Any]:
+        text = text.lower()
+        if re.search(r"\b(trip|vehicle|route|camp|travel)\b", text):
+            return {"target_node": "wheels", "confidence": 0.8}
+        if re.search(r"\b(expense|budget|finance|savings|win)\b", text):
+            return {"target_node": "wins", "confidence": 0.8}
+        if re.search(r"\b(friend|community|social|group)\b", text):
+            return {"target_node": "social", "confidence": 0.8}
+        return {"target_node": "memory", "confidence": 0.5}
+
+    def invoke(self, input: str, config: Optional[RunnableConfig] = None) -> Dict[str, Any]:
+        return self._route(input)
+
+    async def ainvoke(self, input: str, config: Optional[RunnableConfig] = None, **kwargs: Any) -> Dict[str, Any]:
+        return self._route(input)
+
+
+pauter_router = PauterRouter()


### PR DESCRIPTION
## Summary
- create `pauter_router.py` with a simple heuristic router implemented as a LangChain Runnable

## Testing
- `npm test` *(fails: Missing Supabase environment variables)*
- `pytest` *(fails: setup_logging() takes 0 positional arguments but 1 was given)*

------
https://chatgpt.com/codex/tasks/task_e_686b342af67883239f7683bbc3ba3768