### PR TITLE
add PauterRouter

### DIFF
--- a/backend/app/services/pam/mcp/controllers/pauter_router.py
+++ b/backend/app/services/pam/mcp/controllers/pauter_router.py
@@ -5,6 +5,8 @@ from typing import Any, Dict, Optional
 
 from langchain_core.runnables import Runnable, RunnableConfig
 
+__all__ = ["PauterRouter", "pauter_router"]
+
 
 class PauterRouter(Runnable[str, Dict[str, Any]]):
     """Simple heuristic router for PAM nodes."""


### PR DESCRIPTION
## Summary
- expose `PauterRouter` via `__all__` in controllers

## Testing
- `npm run build`
- `npm test` *(fails: Missing Supabase environment variables)*
- `pytest` *(fails: TypeError: setup_logging() takes 0 positional arguments but 1 was given)*

------
https://chatgpt.com/codex/tasks/task_e_686b37a016f08323a5eea8fb71f23107