### PR TITLE
Add micro-agent chain stubs

### DIFF
--- a/backend/app/services/pam/mcp/controllers/memory.py
+++ b/backend/app/services/pam/mcp/controllers/memory.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from app.models.structured_responses import StructuredResponse
+
+__all__ = ["memory_chain"]
+
+async def _call_memory_tools(input_text: str, user_ctx: Dict[str, Any]) -> Dict[str, Any]:
+    """Placeholder for memory node tools."""
+    return {}
+
+async def memory_chain(input_text: str, user_ctx: Dict[str, Any]) -> StructuredResponse:
+    """Micro-agent chain for the memory node."""
+    await _call_memory_tools(input_text, user_ctx)
+    return StructuredResponse(
+        answer_display="memory placeholder",
+        answer_speech="memory placeholder",
+        answer_ssml="memory placeholder",
+    )

--- a/backend/app/services/pam/mcp/controllers/social.py
+++ b/backend/app/services/pam/mcp/controllers/social.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from app.models.structured_responses import StructuredResponse
+
+__all__ = ["social_chain"]
+
+async def _call_social_tools(input_text: str, user_ctx: Dict[str, Any]) -> Dict[str, Any]:
+    """Placeholder for social node tools."""
+    return {}
+
+async def social_chain(input_text: str, user_ctx: Dict[str, Any]) -> StructuredResponse:
+    """Micro-agent chain for the social node."""
+    await _call_social_tools(input_text, user_ctx)
+    return StructuredResponse(
+        answer_display="social placeholder",
+        answer_speech="social placeholder",
+        answer_ssml="social placeholder",
+    )

--- a/backend/app/services/pam/mcp/controllers/wheels.py
+++ b/backend/app/services/pam/mcp/controllers/wheels.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from app.models.structured_responses import StructuredResponse
+
+__all__ = ["wheels_chain"]
+
+async def _call_wheels_tools(input_text: str, user_ctx: Dict[str, Any]) -> Dict[str, Any]:
+    """Placeholder for wheels node tools."""
+    return {}
+
+async def wheels_chain(input_text: str, user_ctx: Dict[str, Any]) -> StructuredResponse:
+    """Micro-agent chain for the wheels node."""
+    await _call_wheels_tools(input_text, user_ctx)
+    return StructuredResponse(
+        answer_display="wheels placeholder",
+        answer_speech="wheels placeholder",
+        answer_ssml="wheels placeholder",
+    )

--- a/backend/app/services/pam/mcp/controllers/wins.py
+++ b/backend/app/services/pam/mcp/controllers/wins.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from app.models.structured_responses import StructuredResponse
+
+__all__ = ["wins_chain"]
+
+async def _call_wins_tools(input_text: str, user_ctx: Dict[str, Any]) -> Dict[str, Any]:
+    """Placeholder for wins node tools."""
+    return {}
+
+async def wins_chain(input_text: str, user_ctx: Dict[str, Any]) -> StructuredResponse:
+    """Micro-agent chain for the wins node."""
+    await _call_wins_tools(input_text, user_ctx)
+    return StructuredResponse(
+        answer_display="wins placeholder",
+        answer_speech="wins placeholder",
+        answer_ssml="wins placeholder",
+    )


### PR DESCRIPTION
## Summary
- add `wheels_chain` stub with placeholder tool call
- add `wins_chain` stub with placeholder tool call
- add `social_chain` stub with placeholder tool call
- add `memory_chain` stub with placeholder tool call

## Testing
- `python -m py_compile backend/app/services/pam/mcp/controllers/wheels.py`
- `python -m py_compile backend/app/services/pam/mcp/controllers/wins.py`


------
https://chatgpt.com/codex/tasks/task_e_686b39fcec688323b6b6ed5ac3938e54