### PR TITLE
Add core PAM chat test

### DIFF
--- a/tests/test_pam.py
+++ b/tests/test_pam.py
@@ -1,0 +1,30 @@
+import os
+import sys
+from pathlib import Path
+import pytest
+from httpx import AsyncClient
+
+# Ensure backend package is importable
+backend_path = Path(__file__).resolve().parent.parent / "backend"
+if str(backend_path) not in sys.path:
+    sys.path.insert(0, str(backend_path))
+
+from app.main import app
+
+# Skip API tests unless enabled
+if os.getenv("RUN_API_TESTS") != "1":
+    pytest.skip("Skipping API tests", allow_module_level=True)
+
+@pytest.fixture
+async def test_client() -> AsyncClient:
+    async with AsyncClient(app=app, base_url="http://test") as client:
+        yield client
+
+@pytest.mark.asyncio
+async def test_pam_chat_hello(test_client: AsyncClient):
+    response = await test_client.post("/api/v1/pam/chat", json={"message": "Hello"})
+    assert response.status_code == 200
+    data = response.json()
+    for field in ["answer_display", "answer_speech", "answer_ssml", "target_node"]:
+        assert field in data
+    assert len(data["answer_speech"].split()) <= 70


### PR DESCRIPTION
## Summary
- add async test for PAM chat endpoint

## Testing
- `RUN_API_TESTS=1 pytest -v` *(fails: setup_logging() takes 0 positional arguments but 1 was given)*

------
https://chatgpt.com/codex/tasks/task_e_686b510f249c8323aa4c4ee17956d038