### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: |
+        pip install -r backend/requirements.txt
+        pip install pytest
+
+    - name: Run tests
+      env:
+        SUPABASE_URL: https://fake.supabase.co
+        SUPABASE_ANON_KEY: fake-key
+      run: pytest


### PR DESCRIPTION
## Summary
- add generic CI workflow for Python tests

## Testing
- `python - <<'PY'
import yaml
print(yaml.safe_load(open('.github/workflows/ci.yml'))['jobs']['test']['runs-on'])
PY`

------
https://chatgpt.com/codex/tasks/task_e_686b5474a93c832384d081a25592d708