### PR TITLE
Update API base & unify WS URLs

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,4 +1,5 @@
-export const API_BASE_URL = import.meta.env.VITE_BACKEND_URL || 'https://pam-backend.onrender.com';
+export const API_BASE_URL =
+  import.meta.env.VITE_BACKEND_URL || 'https://pam-backend.onrender.com';
 
 export function apiFetch(path: string, options: RequestInit = {}) {
   const url = `${API_BASE_URL}${path}`;
@@ -6,12 +7,7 @@ export function apiFetch(path: string, options: RequestInit = {}) {
 }
 
 export function getWebSocketUrl(path: string) {
-  // Use dedicated PAM WebSocket if available
-  if (import.meta.env.VITE_PAM_WEBSOCKET_URL) {
-    return `${import.meta.env.VITE_PAM_WEBSOCKET_URL}${path}`;
-  }
-  
-  // Convert HTTP to WebSocket URL
+  // Convert HTTP base URL to WebSocket protocol
   const baseUrl = API_BASE_URL.replace(/^http/, 'ws');
   return `${baseUrl}${path}`;
 }


### PR DESCRIPTION
## Summary
- point API at `VITE_BACKEND_URL` with default `https://pam-backend.onrender.com`
- derive WebSocket URLs from the same backend URL

## Testing
- `npm test` *(fails: Missing Supabase environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_686b5a06ad04832385438eac7c88c899