### PR TITLE
Add moneymaker tools

### DIFF
--- a/backend/app/services/pam/mcp/tools/__init__.py
+++ b/backend/app/services/pam/mcp/tools/__init__.py
@@ -3,6 +3,11 @@ from .track_expense import track_expense
 from .get_user_context import get_user_context
 from .finance import log_expense, suggest_budget_adjustment, fetch_summary
 from .social import post_update, suggest_groups
+from .moneymaker import (
+    add_idea,
+    list_active_ideas,
+    estimate_monthly_income,
+)
 
 __all__ = [
     "plan_trip",
@@ -13,4 +18,7 @@ __all__ = [
     "fetch_summary",
     "post_update",
     "suggest_groups",
+    "add_idea",
+    "list_active_ideas",
+    "estimate_monthly_income",
 ]

--- a/backend/app/services/pam/mcp/tools/moneymaker.py
+++ b/backend/app/services/pam/mcp/tools/moneymaker.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from langchain_core.tools import tool
+
+from app.database.supabase_client import get_supabase_client
+
+
+@tool
+def add_idea(user_id: str, title: str, description: str = "", tags: Optional[List[str]] = None, avg_earnings: float = 0.0) -> Dict[str, Any]:
+    """Add a money-making idea for a user."""
+    supabase = get_supabase_client()
+    data = {
+        "user_id": user_id,
+        "title": title,
+        "description": description,
+        "tags": tags or [],
+        "avg_earnings": avg_earnings,
+    }
+    result = supabase.table("hustle_ideas").insert(data).execute()
+    return result.data[0] if result.data else {}
+
+
+@tool
+def list_active_ideas(user_id: str) -> List[Dict[str, Any]]:
+    """List a user's active money-making ideas."""
+    supabase = get_supabase_client()
+    result = (
+        supabase.table("hustle_ideas")
+        .select("*")
+        .eq("user_id", user_id)
+        .neq("status", "rejected")
+        .order("created_at")
+        .execute()
+    )
+    return result.data or []
+
+
+@tool
+def estimate_monthly_income(user_id: str) -> float:
+    """Estimate monthly income from approved hustle ideas."""
+    supabase = get_supabase_client()
+    result = (
+        supabase.table("hustle_ideas")
+        .select("avg_earnings")
+        .eq("user_id", user_id)
+        .eq("status", "approved")
+        .execute()
+    )
+    return sum(float(item["avg_earnings"]) for item in (result.data or []))


### PR DESCRIPTION
## Summary
- add a MoneyMaker toolset to pam/mcp tools
- export new MoneyMaker tools via tools `__init__`

## Testing
- `python -m py_compile backend/app/services/pam/mcp/tools/moneymaker.py`


------
https://chatgpt.com/codex/tasks/task_e_686b7164fb948323ad526d2f8bea95e4