### PR TITLE
Add new affiliate shop tool

### DIFF
--- a/backend/app/services/pam/mcp/tools/__init__.py
+++ b/backend/app/services/pam/mcp/tools/__init__.py
@@ -8,6 +8,7 @@ from .moneymaker import (
     list_active_ideas,
     estimate_monthly_income,
 )
+from .shop import suggest_affiliate_product
 
 __all__ = [
     "plan_trip",
@@ -21,4 +22,5 @@ __all__ = [
     "add_idea",
     "list_active_ideas",
     "estimate_monthly_income",
+    "suggest_affiliate_product",
 ]

--- a/backend/app/services/pam/mcp/tools/shop.py
+++ b/backend/app/services/pam/mcp/tools/shop.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from langchain_core.tools import tool
+
+CATALOG_FILE = Path(__file__).resolve().parents[6] / "data" / "affiliate_catalog.json"
+
+
+@tool
+async def suggest_affiliate_product(vehicle_type: str, region: str) -> Dict[str, Any]:
+    """Suggest an affiliate product for a given vehicle type and region."""
+    if not CATALOG_FILE.exists():
+        return {}
+
+    with open(CATALOG_FILE) as f:
+        catalog: List[Dict[str, Any]] = json.load(f)
+
+    for product in catalog:
+        if product.get("vehicle_type") == vehicle_type and region in product.get("regions", []):
+            return product
+
+    for product in catalog:
+        if product.get("vehicle_type") == vehicle_type:
+            return product
+
+    return {}


### PR DESCRIPTION
## Summary
- add `suggest_affiliate_product` tool for PAM
- expose the new tool in MCP tools

## Testing
- `npm run type-check`
- `python -m py_compile backend/app/services/pam/mcp/tools/shop.py`
- `pytest -q` *(fails: setup_logging takes 0 positional arguments)*

------
https://chatgpt.com/codex/tasks/task_e_686b74d8d34483238183893dbe9152de