### PR TITLE
Add shop PAM chain and router keywords

### DIFF
--- a/backend/app/services/pam/mcp/controllers/pauter_router.py
+++ b/backend/app/services/pam/mcp/controllers/pauter_router.py
@@ -11,11 +11,12 @@ __all__ = ["PauterRouter", "pauter_router"]
 class PauterRouter(Runnable[str, Dict[str, Any]]):
     """Simple heuristic router for PAM nodes with confidence scores."""
 
-    VALID_NODES = {"wheels", "wins", "social", "memory"}
+    VALID_NODES = {"wheels", "wins", "social", "memory", "shop"}
     _PATTERNS = {
         "wheels": re.compile(r"\b(trip|vehicle|route|camp|travel)\b"),
         "wins": re.compile(r"\b(expense|budget|finance|savings|win)\b"),
         "social": re.compile(r"\b(friend|community|social|group)\b"),
+        "shop": re.compile(r"\b(shop|purchase|buy|product)\b"),
     }
 
     def _route(self, text: str) -> Dict[str, Any]:

--- a/backend/app/services/pam/mcp/controllers/shop.py
+++ b/backend/app/services/pam/mcp/controllers/shop.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from app.models.structured_responses import StructuredResponse
+from app.services.pam.mcp.tools import suggest_affiliate_product, get_user_context
+
+__all__ = ["shop_chain"]
+
+async def _call_shop_tools(input_text: str, user_ctx: Dict[str, Any]) -> Dict[str, Any]:
+    """Invoke shop micro-agent tools."""
+    context = await get_user_context(user_ctx)
+    # In a real agent we'd parse user input for vehicle type and region
+    vehicle_type = user_ctx.get("vehicle_type", "car")
+    region = user_ctx.get("region", "au")
+    product = await suggest_affiliate_product(vehicle_type, region)
+    return {"context": context, "product": product}
+
+
+async def shop_chain(input_text: str, user_ctx: Dict[str, Any]) -> StructuredResponse:
+    """Micro-agent chain for the shop node."""
+    data = await _call_shop_tools(input_text, user_ctx)
+    product = data.get("product", {})
+    name = product.get("name", "a product")
+    answer_speech = f"I found {name} you might like."
+    return StructuredResponse(
+        answer_display=f"Suggested product: {name}",
+        answer_speech=answer_speech,
+        answer_ssml=f"<speak>{answer_speech}</speak>",
+        ui_actions=[{"type": "navigate", "url": "/shop"}],
+        memory_updates=data,
+    )


### PR DESCRIPTION
## Summary
- implement `shop_chain` micro-agent
- route `shop` keywords in `PauterRouter`

## Testing
- `python -m py_compile backend/app/services/pam/mcp/controllers/shop.py`
- `pip install -r backend/requirements-dev.txt` *(fails: setup_logging errors)*
- `pytest -q` *(fails: 3 errors during collection)*
- `npm install` *(fails: ERESOLVE dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_686b768147cc83238e4ced07d9d65e31