### PR TITLE
Add stripe webhook handler

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -31,6 +31,7 @@ from app.services.sentry_service import sentry_service
 
 # Import API routers
 from app.api.v1 import health, chat, wins, wheels, social, monitoring, pam, auth, subscription, support
+from app.webhooks import stripe_webhooks
 
 logger = setup_logging()
 
@@ -128,6 +129,7 @@ app.include_router(pam.router, prefix="/api", tags=["PAM"])
 app.include_router(auth.router, prefix="/api/auth", tags=["Authentication"])
 app.include_router(subscription.router, prefix="/api/v1", tags=["Subscription"])
 app.include_router(support.router, prefix="/api", tags=["Support"])
+app.include_router(stripe_webhooks.router, prefix="/api", tags=["Webhooks"])
 
 # LangServe router for PauterRouter
 pauter_router = PauterRouter()

--- a/backend/app/webhooks/__init__.py
+++ b/backend/app/webhooks/__init__.py
@@ -1,0 +1,3 @@
+from . import stripe_webhooks
+
+__all__ = ['stripe_webhooks']

--- a/backend/app/webhooks/stripe_webhooks.py
+++ b/backend/app/webhooks/stripe_webhooks.py
@@ -1,0 +1,47 @@
+import json
+import logging
+
+from fastapi import APIRouter, Request, HTTPException
+import stripe
+
+from app.core.config import settings
+from app.core.database import get_supabase_client
+
+router = APIRouter(tags=["Webhooks"])
+
+stripe.api_key = getattr(settings, "STRIPE_SECRET_KEY", None)
+WEBHOOK_SECRET = getattr(settings, "STRIPE_WEBHOOK_SECRET", "")
+logger = logging.getLogger(__name__)
+
+
+@router.post("/webhooks/stripe")
+async def stripe_webhook(request: Request):
+    """Handle Stripe webhook events."""
+    payload = await request.body()
+    sig_header = request.headers.get("stripe-signature")
+    try:
+        if WEBHOOK_SECRET:
+            event = stripe.Webhook.construct_event(payload, sig_header, WEBHOOK_SECRET)
+        else:
+            event = stripe.Event.construct_from(json.loads(payload.decode()), stripe.api_key)
+    except Exception as exc:
+        logger.error(f"Stripe webhook error: {exc}")
+        raise HTTPException(status_code=400, detail="Invalid payload")
+
+    if event.get("type") == "checkout.session.completed":
+        session = event["data"]["object"]
+        record = {
+            "session_id": session.get("id"),
+            "customer_email": session.get("customer_details", {}).get("email"),
+            "amount_total": session.get("amount_total"),
+            "currency": session.get("currency"),
+            "affiliate_id": (session.get("metadata") or {}).get("affiliate_id"),
+        }
+        supabase = get_supabase_client()
+        try:
+            supabase.table("affiliate_sales").insert(record).execute()
+        except Exception as exc:
+            logger.error(f"Failed to store affiliate sale: {exc}")
+            raise HTTPException(status_code=500, detail="Supabase insert failed")
+
+    return {"status": "success"}


### PR DESCRIPTION
## Summary
- add stripe webhook route for checkout session completion
- wire webhook into FastAPI main app

## Testing
- `npm install --legacy-peer-deps`
- `npm test` *(fails: Missing Supabase environment variables)*
- `pip install -r backend/requirements-dev.txt`
- `pytest` *(fails: missing settings & logging errors)*

------
https://chatgpt.com/codex/tasks/task_e_686b78fa04c083239244ed4637ec8c51