### PR TITLE
Add celery config

### DIFF
--- a/celery.py
+++ b/celery.py
@@ -1,0 +1,7 @@
+from celery import Celery
+
+app = Celery('wheels_wins')
+app.config_from_object('celeryconfig')
+
+if __name__ == '__main__':
+    app.start()

--- a/celeryconfig.py
+++ b/celeryconfig.py
@@ -1,0 +1,11 @@
+from datetime import timedelta
+
+broker_url = 'redis://localhost:6379/0'
+result_backend = 'redis://localhost:6379/0'
+
+beat_schedule = {
+    'proactive-checks': {
+        'task': 'tasks.proactive_checks',
+        'schedule': timedelta(seconds=15 * 60),
+    },
+}


### PR DESCRIPTION
## Summary
- setup Celery app with Redis broker
- configure beat schedule to run `tasks.proactive_checks` every 15 minutes

## Testing
- `pip install -r backend/requirements-dev.txt`
- `pytest -q` *(fails: Settings object has no attribute 'SECRET_KEY')*

------
https://chatgpt.com/codex/tasks/task_e_686b8b6a3e2c8323998201e71e1a259f