### PR TITLE
feedback-aware router

### DIFF
--- a/backend/app/services/pam/mcp/controllers/pauter_router.py
+++ b/backend/app/services/pam/mcp/controllers/pauter_router.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Deque
+from collections import deque
 
 from langchain_core.runnables import Runnable, RunnableConfig
 
@@ -19,14 +20,36 @@ class PauterRouter(Runnable[str, Dict[str, Any]]):
         "shop": re.compile(r"\b(shop|purchase|buy|product)\b"),
     }
 
+    def __init__(self, feedback_window: int = 5) -> None:
+        self.feedback_window = feedback_window
+        self.feedback_scores: Dict[str, Deque[float]] = {
+            node: deque(maxlen=feedback_window) for node in self.VALID_NODES
+        }
+
+    def update_feedback(self, node: str, rating: float) -> None:
+        """Record a rating for a node."""
+        if node in self.feedback_scores:
+            self.feedback_scores[node].append(rating)
+
+    def _feedback_weight(self, node: str) -> float:
+        scores = self.feedback_scores.get(node)
+        if scores:
+            avg = sum(scores) / len(scores)
+            return max(0.5, min(1.5, avg / 3.0))
+        return 1.0
+
     def _route(self, text: str) -> Dict[str, Any]:
         text = text.lower()
         for node, pattern in self._PATTERNS.items():
             matches = pattern.findall(text)
             if matches:
-                confidence = min(1.0, 0.6 + 0.1 * len(matches))
+                base = min(1.0, 0.6 + 0.1 * len(matches))
+                confidence = min(1.0, base * self._feedback_weight(node))
                 return {"target_node": node, "confidence": confidence}
-        return {"target_node": "memory", "confidence": 0.4}
+        return {
+            "target_node": "memory",
+            "confidence": min(1.0, 0.4 * self._feedback_weight("memory")),
+        }
 
     def invoke(self, input: str, config: Optional[RunnableConfig] = None) -> Dict[str, Any]:
         return self._route(input)


### PR DESCRIPTION
## Summary
- update PauterRouter routing to incorporate feedback using a moving average

## Testing
- `python -m py_compile backend/app/services/pam/mcp/controllers/pauter_router.py`
- `pytest -q` *(fails: setup_logging() takes 0 positional arguments but 1 was given)*

------
https://chatgpt.com/codex/tasks/task_e_686b936d5b3c832387d53b6cb2d2520a