### PR TITLE
Add tests for PAM feedback and proactive checks

### DIFF
--- a/backend/tests/api/test_pam_feedback_endpoint.py
+++ b/backend/tests/api/test_pam_feedback_endpoint.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+from httpx import AsyncClient
+
+if os.getenv("RUN_API_TESTS") != "1":
+    pytest.skip("Skipping API tests", allow_module_level=True)
+
+
+class TestPamFeedbackEndpoint:
+    """Tests for the /api/v1/pam/feedback endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_pam_thumb_feedback(self, test_client: AsyncClient):
+        payload = {
+            "message_id": "msg-123",
+            "thumbs_up": True
+        }
+        response = await test_client.post("/api/v1/pam/feedback", json=payload)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["message"] == "Feedback recorded"
+

--- a/backend/tests/unit/test_proactive_checks.py
+++ b/backend/tests/unit/test_proactive_checks.py
@@ -1,0 +1,19 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from app.tasks.proactive_checks import run_proactive_checks
+
+
+class TestProactiveChecks:
+    """Unit tests for the proactive checks task."""
+
+    @pytest.mark.asyncio
+    async def test_run_proactive_checks_dry_run(self):
+        with patch("app.tasks.proactive_checks._get_active_users", return_value=[{"user_id": "123", "region": "AU"}]):
+            with patch("app.tasks.proactive_checks._get_budget_info", return_value=[]):
+                with patch("app.tasks.proactive_checks._prefetch_tomorrow_camps", return_value=[]):
+                    with patch("app.tasks.proactive_checks._get_weather_alert", return_value={"alert": "rain"}):
+                        with patch("app.tasks.proactive_checks.manager.send_message_to_user", new=AsyncMock()) as mock_send:
+                            await run_proactive_checks()
+                            mock_send.assert_called_once()
+


### PR DESCRIPTION
## Summary
- add API test for `/api/v1/pam/feedback`
- test proactive checks in dry-run mode

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'warning')*

------
https://chatgpt.com/codex/tasks/task_e_686b9931ea248323a2ea12f1d5bd2d07