### PR TITLE
Add Celery worker to Render blueprint

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -40,3 +40,36 @@ services:
     name: pam-redis
     plan: free
     ipAllowList: []
+  - type: worker
+    name: pam-celery-worker
+    env: python
+    runtime: python-3.11
+    rootDir: backend
+    buildCommand: pip install -r requirements.txt
+    startCommand: celery -A app.workers.celery worker --loglevel=info
+    envVars:
+      - key: ENVIRONMENT
+        value: production
+      - key: OPENAI_API_KEY
+        sync: false
+      - key: SUPABASE_URL
+        sync: false
+      - key: SUPABASE_KEY
+        sync: false
+      - key: SUPABASE_ANON_KEY
+        sync: false
+      - key: SECRET_KEY
+        generateValue: true
+      - key: CORS_ORIGINS
+        sync: false
+      - key: SENTRY_DSN
+        sync: false
+      - key: LANGCHAIN_TRACING_V2
+        value: disabled
+      - key: REDIS_URL
+        fromService:
+          type: redis
+          name: pam-redis
+          property: connectionString
+    autoDeploy: true
+


### PR DESCRIPTION
## Summary
- add Celery worker service to Render blueprint so background tasks run alongside the web app

## Testing
- `pytest -q` *(fails: AttributeError and TypeError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_686b9e0c4f488323a3c8f63b4e67e82a