### PR TITLE
Fix mapbox env loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ VITE_SUPABASE_ANON_KEY=<your-supabase-anon-key>
 
 These values are read in `src/integrations/supabase/client.ts` when initializing the Supabase client.
 
+The trip planner requires a Mapbox token for map display. A default token is provided in `src/.env`, and the Vite configuration now loads this file automatically. If you need to use your own Mapbox account, set `VITE_MAPBOX_TOKEN` in a `.env` file at the project root or replace the token in `src/.env`.
+
 ## Running Tests
 
 Before committing changes, run the project's test suites.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig(({ mode }) => ({
     host: "::",
     port: 8080,
   },
+  envDir: path.resolve(__dirname, "src"),
   plugins: [
     react(),
     mode === "development" && componentTagger(),


### PR DESCRIPTION
## Summary
- use `envDir` so Vite loads `.env` from `src`
- document Mapbox token setup in README

## Testing
- `npm test` *(fails: useAuth must be used within an AuthProvider)*

------
https://chatgpt.com/codex/tasks/task_e_686c554b2e748323890f70401137be77