### PR TITLE
Fix WebSocket connection handling

### DIFF
--- a/backend/app/api/v1/pam.py
+++ b/backend/app/api/v1/pam.py
@@ -5,7 +5,6 @@ from typing import List, Optional, Dict, Any
 import json
 import uuid
 import logging
-import asyncio
 from datetime import datetime
 
 from app.api.deps import (
@@ -26,39 +25,7 @@ router = APIRouter()
 logger = setup_logging()
 
 
-async def _safe_connect(websocket: WebSocket, user_id: str, connection_id: str):
-    """Call ConnectionManager.connect with backward compatibility."""
-    try:
-        await _safe_connect(websocket, user_id, connection_id)
-    except TypeError:
-        await manager.connect(websocket, user_id)
 
-
-async def _safe_disconnect(websocket: WebSocket, user_id: str, connection_id: str):
-    """Call ConnectionManager.disconnect handling sync/async variants."""
-    disconnect = getattr(manager, "disconnect", None)
-    if not disconnect:
-        return
-
-    try:
-        if asyncio.iscoroutinefunction(disconnect):
-            try:
-                await disconnect(user_id, connection_id)
-            except TypeError:
-                try:
-                    await disconnect(websocket, user_id)
-                except TypeError:
-                    await disconnect(user_id)
-        else:
-            try:
-                disconnect(user_id, connection_id)
-            except TypeError:
-                try:
-                    disconnect(websocket, user_id)
-                except TypeError:
-                    disconnect(user_id)
-    except Exception as err:
-        logger.error(f"Disconnect error: {err}")
 
 # WebSocket endpoint for real-time chat
 @router.websocket("/ws")
@@ -87,7 +54,7 @@ async def websocket_endpoint(
             # Fall back to treating token as plain user_id
             user_id = token
         
-        await _safe_connect(websocket, user_id, connection_id)
+        await manager.connect(websocket, user_id, connection_id)
         
         # Send welcome message
         await websocket.send_json({
@@ -119,11 +86,11 @@ async def websocket_endpoint(
                 })
                 
     except WebSocketDisconnect:
-        await _safe_disconnect(websocket, user_id, connection_id)
+        await manager.disconnect(user_id, connection_id)
         logger.info(f"WebSocket client {user_id} disconnected")
     except Exception as e:
         logger.error(f"WebSocket error: {str(e)}")
-        await _safe_disconnect(websocket, user_id, connection_id)
+        await manager.disconnect(user_id, connection_id)
         try:
             await websocket.close(code=1011, reason="Internal server error")
         except:

--- a/backend/app/core/websocket_manager.py
+++ b/backend/app/core/websocket_manager.py
@@ -1,38 +1,32 @@
-from typing import List, Dict
-import asyncio
-import json
+from typing import Dict
 from fastapi import WebSocket
 
 class ConnectionManager:
     def __init__(self):
-        self.active_connections: List[WebSocket] = []
-        self.user_connections: Dict[str, WebSocket] = {}
-        # Allow multiple connections per user via connection IDs
-        self.connection_map: Dict[str, Dict[str, WebSocket]] = {}
+        # Map connection_id -> WebSocket
+        self.active_connections: Dict[str, WebSocket] = {}
+        # Map user_id -> {connection_id -> WebSocket}
+        self.user_connections: Dict[str, Dict[str, WebSocket]] = {}
 
-    async def connect(self, websocket: WebSocket, user_id: str = None, connection_id: str = None):
-        """Register a new WebSocket connection"""
+    async def connect(self, websocket: WebSocket, user_id: str, connection_id: str) -> None:
+        """Register a new WebSocket connection."""
         await websocket.accept()
-        self.active_connections.append(websocket)
-        if user_id:
-            self.user_connections[user_id] = websocket
-            if connection_id:
-                if user_id not in self.connection_map:
-                    self.connection_map[user_id] = {}
-                self.connection_map[user_id][connection_id] = websocket
+        self.active_connections[connection_id] = websocket
+        if user_id not in self.user_connections:
+            self.user_connections[user_id] = {}
+        self.user_connections[user_id][connection_id] = websocket
 
-    async def disconnect(self, user_id: str, connection_id: str = None):
-        """Remove a WebSocket connection"""
-        websocket = None
-        if connection_id and user_id in self.connection_map:
-            websocket = self.connection_map[user_id].pop(connection_id, None)
-            if not self.connection_map[user_id]:
-                del self.connection_map[user_id]
-        if not websocket and user_id in self.user_connections:
-            websocket = self.user_connections.pop(user_id)
+    async def disconnect(self, user_id: str, connection_id: str) -> None:
+        """Remove a WebSocket connection."""
+        websocket = self.user_connections.get(user_id, {}).pop(connection_id, None)
+        if user_id in self.user_connections and not self.user_connections[user_id]:
+            self.user_connections.pop(user_id, None)
 
-        if websocket and websocket in self.active_connections:
-            self.active_connections.remove(websocket)
+        if websocket is None:
+            websocket = self.active_connections.get(connection_id)
+
+        if websocket:
+            self.active_connections.pop(connection_id, None)
 
     async def send_personal_message(self, message: str, websocket: WebSocket):
         if isinstance(message, (dict, list)):
@@ -42,16 +36,17 @@ class ConnectionManager:
 
     async def send_message_to_user(self, message: str, user_id: str):
         if user_id in self.user_connections:
-            websocket = self.user_connections[user_id]
-            await self.send_personal_message(message, websocket)
+            # Send to all active connections for this user
+            for ws in list(self.user_connections[user_id].values()):
+                await self.send_personal_message(message, ws)
 
     async def broadcast(self, message: str):
-        for connection in self.active_connections:
+        for connection_id, connection in list(self.active_connections.items()):
             try:
                 await connection.send_text(message)
-            except:
+            except Exception:
                 # Remove dead connections
-                self.active_connections.remove(connection)
+                self.active_connections.pop(connection_id, None)
 
 # Create the manager instance
 manager = ConnectionManager()


### PR DESCRIPTION
## Summary
- update `ConnectionManager` to track connections by ID
- remove backward-compatible wrappers and call new async API directly
- clean up websocket endpoint logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'asyncpg')*

------
https://chatgpt.com/codex/tasks/task_e_686c80e843e08323b8db9f3f0e05e725