### PR TITLE
Fix websocket disconnect method - remove async

### DIFF
--- a/backend/app/api/websocket.py
+++ b/backend/app/api/websocket.py
@@ -111,11 +111,11 @@ async def websocket_endpoint(
                 })
 
     except WebSocketDisconnect:
-        await manager.disconnect(user_id, connection_id)
+        manager.disconnect(user_id, connection_id)
         logger.info(f"WebSocket disconnected: {user_id}")
 
     except Exception as e:
-        await manager.disconnect(user_id, connection_id)
+        manager.disconnect(user_id, connection_id)
         logger.error(f"WebSocket error for {user_id}: {e}")
         try:
             await websocket.close(code=1011, reason="Internal error")

--- a/backend/app/core/websocket_manager.py
+++ b/backend/app/core/websocket_manager.py
@@ -17,7 +17,7 @@ class ConnectionManager:
             self.user_connections[user_id] = {}
         self.user_connections[user_id][connection_id] = websocket
     
-    async def disconnect(self, user_id: str, connection_id: str) -> None:
+    def disconnect(self, user_id: str, connection_id: str) -> None:
         """Remove a WebSocket connection."""
         websocket = self.user_connections.get(user_id, {}).pop(connection_id, None)
         


### PR DESCRIPTION
## Summary
- fix websocket disconnect method by removing `async`
- remove awaiting disconnect calls when closing websockets

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'asyncpg')*

------
https://chatgpt.com/codex/tasks/task_e_686cb066bd088323942d37bd03b99440