### PR TITLE
Fix Pillow version

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -64,7 +64,7 @@ healthcheck==1.3.3
 
 # File handling
 python-magic==0.4.27
-pillow==10.3.0
+pillow==11.0.0
 
 # Utilities
 uuid==1.30


### PR DESCRIPTION
## Summary
- update Pillow in `backend/requirements.txt` to 11.0.0 for Python 3.13 compatibility

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686cb31be0d88323aff253e9d7f22283