### PR TITLE
Add asyncpg dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,6 +20,7 @@ stripe==9.8.0
 # Database and caching
 redis==5.0.7
 sqlalchemy[asyncio]==2.0.23
+asyncpg==0.29.0
 
 # Background tasks
 celery==5.4.0


### PR DESCRIPTION
## Summary
- enable async PostgreSQL support in backend requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'asyncpg')*

------
https://chatgpt.com/codex/tasks/task_e_686cb8f2ffbc8323a9393838ed11bae7