### PR TITLE
Fix missing asyncpg dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,7 +20,7 @@ stripe==9.8.0
 # Database and caching
 redis==5.0.7
 sqlalchemy[asyncio]==2.0.23
-asyncpg==0.29.0
+asyncpg==0.30.0
 
 # Background tasks
 celery==5.4.0


### PR DESCRIPTION
## Summary
- pin `asyncpg` in backend/requirements

## Testing
- `pytest -q` *(fails: AttributeError in tests during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686cba708cd88323ac658f900e27e983