### PR TITLE
Fix Render entrypoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,94 +1,81 @@
+"""Entry point for deploying the FastAPI application on Render.
+
+This module imports the main FastAPI instance defined in
+``backend/app/main.py``.  It is intentionally lightweight so that
+``uvicorn`` can load ``app:app`` without running into the module name
+clashes that occur when this file is also named ``app``.
+
+If the backend application fails to import, a minimal FastAPI app is
+exposed so that the deployment can still start and return a helpful
+error message.
 """
-Production entry point for Wheels & Wins Backend
-Handles both development and production environments
-"""
-import sys
-import os
+
+from __future__ import annotations
+
+import importlib.util
 import logging
+import os
+import sys
 from pathlib import Path
 
-# Configure logging
+from fastapi import FastAPI
+
+
 logging.basicConfig(
     level=logging.INFO,
-    format='{"timestamp": "%(asctime)s", "level": "%(levelname)s", "message": "%(message)s", "module": "%(name)s"}',
-    datefmt='%Y-%m-%dT%H:%M:%S'
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
 )
-
 logger = logging.getLogger(__name__)
 
-def setup_python_path():
-    """Add necessary directories to Python path"""
-    current_dir = Path(__file__).parent
-    backend_dir = current_dir / "backend"
-    
-    # Add both root and backend to path for maximum compatibility
-    paths_to_add = [str(current_dir), str(backend_dir)]
-    
-    for path in paths_to_add:
-        if path not in sys.path:
-            sys.path.insert(0, path)
-            logger.info(f"Added {path} to Python path")
 
-def get_fastapi_app():
-    """Import and return the FastAPI application"""
+def _load_backend_app() -> FastAPI:
+    """Load the FastAPI application from ``backend/app/main.py``."""
+
+    project_root = Path(__file__).resolve().parent
+    backend_path = project_root / "backend"
+
+    # Ensure the backend package is importable
+    if str(backend_path) not in sys.path:
+        sys.path.insert(0, str(backend_path))
+        logger.info("Added %s to PYTHONPATH", backend_path)
+
+    # Remove this module from ``sys.modules`` to prevent clashes with the
+    # ``app`` package inside ``backend``.
+    sys.modules.pop("app", None)
+
+    main_file = backend_path / "app" / "main.py"
+    spec = importlib.util.spec_from_file_location("backend_main", main_file)
+    module = importlib.util.module_from_spec(spec)
+
     try:
-        # Setup paths first
-        setup_python_path()
-        
-        # Try to import from backend structure first (production)
-        try:
-            from app.main import app
-            logger.info("Successfully imported FastAPI app from backend structure")
-            return app
-        except ImportError as e:
-            logger.warning(f"Backend import failed: {e}")
-            
-            # Fallback: try direct import (development)
-            try:
-                import importlib.util
-                spec = importlib.util.spec_from_file_location("main", "backend/app/main.py")
-                main_module = importlib.util.module_from_spec(spec)
-                spec.loader.exec_module(main_module)
-                app = main_module.app
-                logger.info("Successfully imported FastAPI app via direct file import")
-                return app
-            except Exception as fallback_error:
-                logger.error(f"All import methods failed: {fallback_error}")
-                raise ImportError("Could not import FastAPI app from any location")
-                
-    except Exception as e:
-        logger.error(f"Failed to get FastAPI app: {e}")
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        logger.info("Successfully imported backend app from %s", main_file)
+        return getattr(module, "app")
+    except Exception as exc:  # pragma: no cover - import failure path
+        logger.exception("Failed to load backend FastAPI app: %s", exc)
         raise
 
-# Get the app instance
+
 try:
-    app = get_fastapi_app()
-    logger.info("Wheels & Wins Backend initialized successfully")
-except Exception as e:
-    logger.error(f"Failed to initialize backend: {e}")
-    # Create a minimal error app for debugging
-    from fastapi import FastAPI
-    app = FastAPI(title="Wheels & Wins Backend - Error State")
-    
+    app = _load_backend_app()
+except Exception as import_error:
+    # Fallback application shown when the backend fails to import
+    app = FastAPI(title="Wheels & Wins Backend - Error")
+
     @app.get("/")
-    async def error_root():
+    async def import_failure_root() -> dict[str, str]:
         return {
-            "status": "error",
-            "message": "Backend initialization failed",
-            "error": str(e),
-            "instructions": "Check logs for detailed error information"
+            "error": "Backend application failed to load",
+            "details": str(import_error),
         }
 
-if __name__ == "__main__":
+
+if __name__ == "__main__":  # pragma: no cover - manual launch
     import uvicorn
-    port = int(os.environ.get("PORT", 8000))
-    host = os.environ.get("HOST", "0.0.0.0")
-    
-    logger.info(f"Starting Wheels & Wins Backend on {host}:{port}")
-    uvicorn.run(
-        "app:app",
-        host=host,
-        port=port,
-        log_level="info",
-        access_log=True
-    )
+
+    host = os.getenv("HOST", "0.0.0.0")
+    port = int(os.getenv("PORT", "8000"))
+    logger.info("Starting Uvicorn on %s:%s", host, port)
+    uvicorn.run("app:app", host=host, port=port, log_level="info")
+


### PR DESCRIPTION
## Summary
- clean up entrypoint logic in `app.py`
- ensure backend FastAPI app is imported safely with detailed logging
- provide fallback FastAPI instance when import fails

## Testing
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'error')*

------
https://chatgpt.com/codex/tasks/task_e_686cbb69cf088323ac7e929f487ac1eb