### PR TITLE
Fix Render entrypoint and dependency

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,9 +39,9 @@ def _load_backend_app() -> FastAPI:
         sys.path.insert(0, str(backend_path))
         logger.info("Added %s to PYTHONPATH", backend_path)
 
-    # Remove this module from ``sys.modules`` to prevent clashes with the
-    # ``app`` package inside ``backend``.
-    sys.modules.pop("app", None)
+    # Ensure this module stays registered so Uvicorn reload works correctly
+    # even after inserting the backend path. Removing it can cause ``app``
+    # to resolve to the backend package instead of this file on reload.
 
     main_file = backend_path / "app" / "main.py"
     spec = importlib.util.spec_from_file_location("backend_main", main_file)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,10 @@ openai==1.35.3
 supabase==2.5.0
 stripe==9.8.0
 
+# Database
+sqlalchemy[asyncio]==2.0.23
+asyncpg==0.30.0
+
 # Background tasks and caching
 redis==5.0.7
 celery==5.4.0


### PR DESCRIPTION
## Summary
- update root `requirements.txt` with async SQLAlchemy and asyncpg
- prevent Reload issues in `app.py` by keeping module registered

## Testing
- `pytest -q`
- `pytest -q tests/test_pam.py` *(fails: AttributeError: 'Settings' object has no attribute 'SECRET_KEY')*

------
https://chatgpt.com/codex/tasks/task_e_686cc60dbb908323a2db87133c578596