### PR TITLE
Fix SQLAlchemy typing issue for Python 3.13

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,7 +19,7 @@ stripe==9.8.0
 
 # Database and caching
 redis==5.0.7
-sqlalchemy[asyncio]==2.0.23
+sqlalchemy[asyncio]==2.0.41
 asyncpg==0.30.0
 
 # Background tasks
@@ -39,7 +39,7 @@ apscheduler==3.10.4
 psutil==6.1.0
 
 # Error tracking and monitoring
-sentry-sdk[fastapi]==1.45.1
+sentry-sdk[fastapi]==2.32.0
 
 # Logging
 structlog==23.2.0


### PR DESCRIPTION
## Summary
- update SQLAlchemy and Sentry SDK versions in `backend/requirements.txt` to resolve typing conflict under Python 3.13

## Testing
- `pytest -q` *(fails: AttributeError 'NoneType' object has no attribute 'error' during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686cd000613c83238399d3ce39c744e1