### PR TITLE
Fix PAM widget backend URLs

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,5 @@
 VITE_BACKEND_URL=https://pam-backend.onrender.com
+VITE_PAM_WEBSOCKET_URL=wss://pam-backend.onrender.com/api/ws
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_ANON_KEY=your_supabase_anon_key
 SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key

--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,8 @@ SUPABASE_SERVICE_ROLE_KEY=dev-service-role-key
 
 # Backend API
 VITE_BACKEND_URL=https://pam-backend.onrender.com
+# WebSocket endpoint for PAM (override if needed)
+VITE_PAM_WEBSOCKET_URL=wss://pam-backend.onrender.com/api/ws
 
 # Mapbox public access token (should start with 'pk.')
 VITE_MAPBOX_TOKEN=pk.your_mapbox_token_here

--- a/.env.production
+++ b/.env.production
@@ -23,4 +23,5 @@ SECRET_KEY=
 # CORS settings
 ALLOWED_ORIGINS=["https://yourdomain.com", "https://www.yourdomain.com"]
 VITE_BACKEND_URL=https://pam-backend.onrender.com
+VITE_PAM_WEBSOCKET_URL=wss://pam-backend.onrender.com/api/ws
 VITE_MAPBOX_TOKEN=

--- a/frontend/services/pam.ts
+++ b/frontend/services/pam.ts
@@ -1,5 +1,9 @@
+const BASE_URL =
+  (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_BACKEND_URL) ||
+  'https://pam-backend.onrender.com';
+
 export async function sendToPamChat(message: string): Promise<any> {
-  const response = await fetch('/api/v1/pam/chat', {
+  const response = await fetch(`${BASE_URL}/api/v1/pam/chat`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ message })
@@ -11,7 +15,7 @@ export async function sendToPamChat(message: string): Promise<any> {
 }
 
 export async function sendToPamVoice(audio: Blob): Promise<string | null> {
-  const response = await fetch('/api/v1/pam/voice', {
+  const response = await fetch(`${BASE_URL}/api/v1/pam/voice`, {
     method: 'POST',
     headers: {
       'Content-Type': audio.type || 'application/octet-stream'

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,13 +1,21 @@
 export const API_BASE_URL =
   import.meta.env.VITE_BACKEND_URL || 'https://pam-backend.onrender.com';
 
+// Allow overriding the WebSocket endpoint separately if needed
+const WS_OVERRIDE = import.meta.env.VITE_PAM_WEBSOCKET_URL;
+
 export function apiFetch(path: string, options: RequestInit = {}) {
   const url = `${API_BASE_URL}${path}`;
   return fetch(url, options);
 }
 
 export function getWebSocketUrl(path: string) {
-  // Convert HTTP base URL to WebSocket protocol
+  // Use explicit WebSocket override if provided
+  if (WS_OVERRIDE) {
+    return WS_OVERRIDE;
+  }
+
+  // Otherwise derive from the HTTP base URL
   const baseUrl = API_BASE_URL.replace(/^http/, 'ws');
   return `${baseUrl}${path}`;
 }

--- a/src/services/pamService.ts
+++ b/src/services/pamService.ts
@@ -2,8 +2,8 @@
 export const PAM_CONFIG = {
   // Primary PAM WebSocket endpoints (production ready)
   WEBSOCKET_ENDPOINTS: [
-    'wss://api.wheelsandwins.com/pam/ws',  // Primary production endpoint
-    'wss://pam-backend.onrender.com/ws',   // Backup Render service
+    import.meta.env.VITE_PAM_WEBSOCKET_URL || 'wss://pam-backend.onrender.com/ws',
+    'wss://api.wheelsandwins.com/pam/ws',  // Alternate production endpoint
     'wss://treflip2025.app.n8n.cloud/ws/pam' // N8N WebSocket proxy
   ],
   


### PR DESCRIPTION
## Summary
- default to production backend URL for WebSocket calls
- allow overriding PAM WebSocket via env var
- update chat widget to use configured backend URL
- document websocket env var in `.env` files

## Testing
- `npm test` *(fails: useAuth must be used within an AuthProvider)*

------
https://chatgpt.com/codex/tasks/task_e_686ce49fc4d48323a093779a98e78948