### PR TITLE
Add Coqui TTS library to backend dependencies

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -78,3 +78,5 @@ python-multipart==0.0.20
 langchain==0.2.*
 langserve==0.0.*
 
+
+TTS==1.8.2     # Coqui TTS library used by app.voice.tts_coqui


### PR DESCRIPTION
## Summary
- update backend requirements with `TTS` library used for voice synthesis

## Testing
- `pip install TTS==1.8.2` *(fails: No matching distribution found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'TTS')*

------
https://chatgpt.com/codex/tasks/task_e_686dcd2cf0948323be89ec0f68ba20ed