### PR TITLE
Pin sentry-sdk 1.39.2 in backend

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -39,7 +39,7 @@ apscheduler==3.10.4
 psutil==6.1.0
 
 # Error tracking and monitoring
-sentry-sdk[fastapi]==2.32.0
+sentry-sdk==1.39.2
 
 # Logging
 structlog==23.2.0


### PR DESCRIPTION
## Summary
- pin sentry-sdk to 1.39.2

## Testing
- `pip install -r backend/requirements.txt` *(fails: network unreachable)*
- `pip install pip-audit && pip-audit -r backend/requirements.txt --no-deps --disable-pip` *(fails: Invalid version)*
- `uvicorn backend.app.main:app --port 8000` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686ddc2fabf483238a4cdd7d89063089