### PR TITLE
Configure Render docker deploy

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -64,12 +64,11 @@ RUN groupadd -r pamuser && useradd -r -g pamuser pamuser \
  && chown -R pamuser:pamuser /app
 USER pamuser
 
-# Render uses $PORT (default 10000)
-ENV PORT=10000
-EXPOSE $PORT
+# Render uses port 10000
+EXPOSE 10000
 
 # Health-check Render can query
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
-  CMD curl -f http://localhost:$PORT/health || exit 1
+  CMD curl -f http://localhost:10000/health || exit 1
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "10000"]

--- a/backend/app/tasks/celery_worker.py
+++ b/backend/app/tasks/celery_worker.py
@@ -1,0 +1,9 @@
+import os
+from celery import Celery
+
+celery_app = Celery(
+    "pam",
+    broker=os.environ["REDIS_URL"],
+    backend=os.environ.get("REDIS_URL"),
+)
+celery_app.autodiscover_tasks(["app.tasks"])

--- a/render.yaml
+++ b/render.yaml
@@ -1,75 +1,42 @@
-
-# Root render.yaml - points to backend structure
 services:
   - type: web
-    name: pam-backend
-    env: python
-    plan: free
-    runtime: python-3.11
-    rootDir: backend
-    buildCommand: pip install -r requirements.txt
-    startCommand: uvicorn app.main:app --host 0.0.0.0 --port $PORT
+    name: pam-web
+    env: docker
+    plan: standard
+    dockerfilePath: ./backend/Dockerfile
+    dockerContext: .
+    autoDeploy: true
     envVars:
-      - key: ENVIRONMENT
-        value: production
-      - key: OPENAI_API_KEY
+      - key: PORT
+        value: "10000"
+      - key: DATABASE_URL
+        sync: false
+      - key: REDIS_URL
         sync: false
       - key: SUPABASE_URL
         sync: false
-      - key: SUPABASE_KEY
+      - key: SUPABASE_SERVICE_ROLE_KEY
         sync: false
-      - key: LANGCHAIN_TRACING_V2
-        value: disabled
-      - key: SUPABASE_ANON_KEY
-        sync: false
-      - key: SECRET_KEY
-        generateValue: true
-      - key: CORS_ORIGINS
+      - key: OPENAI_API_KEY
         sync: false
       - key: SENTRY_DSN
         sync: false
-      - key: REDIS_URL
-        fromService:
-          type: redis
-          name: pam-redis
-          property: connectionString
-    autoDeploy: true
-    healthCheckPath: /api/health
-
-  - type: redis
-    name: pam-redis
-    plan: free
-    ipAllowList: []
+    healthCheckPath: /health
+    disk:
+      name: cache
+      mountPath: /cache
+      sizeGB: 1
   - type: worker
-    name: pam-celery-worker
-    env: python
-    runtime: python-3.11
-    rootDir: backend
-    buildCommand: pip install -r requirements.txt
-    startCommand: celery -A app.workers.celery worker --loglevel=info
+    name: pam-celery
+    env: docker
+    dockerfilePath: ./backend/Dockerfile
+    dockerContext: .
+    command: >
+      celery -A app.tasks.celery_worker worker
+      --loglevel=info
+      --logfile=/var/log/celery/worker.log
     envVars:
-      - key: ENVIRONMENT
-        value: production
-      - key: OPENAI_API_KEY
-        sync: false
-      - key: SUPABASE_URL
-        sync: false
-      - key: SUPABASE_KEY
-        sync: false
-      - key: SUPABASE_ANON_KEY
-        sync: false
-      - key: SECRET_KEY
-        generateValue: true
-      - key: CORS_ORIGINS
-        sync: false
-      - key: SENTRY_DSN
-        sync: false
-      - key: LANGCHAIN_TRACING_V2
-        value: disabled
-      - key: REDIS_URL
-        fromService:
-          type: redis
-          name: pam-redis
-          property: connectionString
-    autoDeploy: true
-
+      - fromService:
+          type: web
+          name: pam-web
+          envVarKey: REDIS_URL


### PR DESCRIPTION
## Summary
- add Render services config
- run app on port 10000
- create celery worker entrypoint

## Testing
- `npm test` *(fails: useAuth must be used within an AuthProvider)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'structlog')*
- `docker build -t pam-local -f backend/Dockerfile .` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dde78cda08323a576747dcf40b6af