### PR TITLE
Fix docs references to backend directory

### DIFF
--- a/docs/guides/development/code-structure.md
+++ b/docs/guides/development/code-structure.md
@@ -116,7 +116,7 @@ type UserAction = 'create' | 'update' | 'delete';
 
 ### Directory Organization
 ```
-pam-backend/
+backend/
 ├── app/
 │   ├── api/                # API route handlers
 │   │   ├── __init__.py

--- a/docs/guides/setup/initial-setup.md
+++ b/docs/guides/setup/initial-setup.md
@@ -36,7 +36,7 @@ This guide walks you through setting up the PAM system from scratch.
 
 1. **Navigate to Backend Directory**
    ```bash
-   cd pam-backend
+   cd backend
    ```
 
 2. **Install Python Dependencies**

--- a/docs/guides/troubleshooting/deployment-issues.md
+++ b/docs/guides/troubleshooting/deployment-issues.md
@@ -50,7 +50,7 @@ CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "10000"]
 # 1. Check build logs in Render dashboard
 # 2. Verify environment variables are set
 # 3. Test locally first:
-cd pam-backend
+cd backend
 pip install -r requirements.txt
 uvicorn app.main:app --reload
 


### PR DESCRIPTION
## Summary
- update docs to point to the correct `backend` folder

## Testing
- `npm test` *(fails: useAuth must be used within an AuthProvider)*
- `pytest` *(fails: setup_logging errors)*

------
https://chatgpt.com/codex/tasks/task_e_686e11803fa88323a7090f3ccde12a57