### PR TITLE
Fix Celery worker entry point

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -16,6 +16,6 @@ services:
     dockerContext: .
     plan: free
     autoDeploy: true
-    startCommand: celery -A backend.worker worker --loglevel=INFO
+    startCommand: celery -A app.workers.celery worker --loglevel=INFO
     envVars:
       - fromGroup: wheels-env


### PR DESCRIPTION
## Summary
- point celery worker to `app.workers.celery` in render.yaml

## Testing
- `npm test` *(fails: useAuth must be used within an AuthProvider)*
- `pytest` *(fails: setup_logging errors, proxy errors)*

------
https://chatgpt.com/codex/tasks/task_e_686e1efaac3083238513ae7729c6bfc8