### PR TITLE
Fix docs for backend URLs

### DIFF
--- a/docs/features/pam-ai-assistant.md
+++ b/docs/features/pam-ai-assistant.md
@@ -15,7 +15,7 @@ PAM uses WebSocket connections for real-time bidirectional communication between
 4. Automatic reconnection with exponential backoff
 
 **Backend URL:** `https://pam-backend.onrender.com`  
-**WebSocket Endpoint:** `wss://pam-backend.onrender.com/ws/{userId}?token={jwt_token}`
+**WebSocket Endpoint:** `wss://pam-backend.onrender.com/api/v1/pam/ws?token={jwt_token}`
 
 ### Context Enrichment System
 PAM receives rich contextual information with each message:
@@ -110,7 +110,7 @@ Refresh tokens when expired to maintain the connection.
 
 ### WebSocket Message Flow
 1. **Connection Establishment**
-   - Frontend connects to `wss://pam-backend.onrender.com/ws/{userId}`
+   - Frontend connects to `wss://pam-backend.onrender.com/api/v1/pam/ws?token={jwt_token}`
    - JWT authentication in URL parameters
    - Automatic reconnection with exponential backoff (max 3 attempts)
 

--- a/docs/guides/setup/initial-setup.md
+++ b/docs/guides/setup/initial-setup.md
@@ -15,7 +15,7 @@ This guide walks you through setting up the PAM system from scratch.
 1. **Clone the Repository**
    ```bash
    git clone <repository-url>
-   cd pam-frontend
+   cd frontend
    ```
 
 2. **Install Dependencies**

--- a/docs/technical/api-documentation.md
+++ b/docs/technical/api-documentation.md
@@ -5,7 +5,7 @@ Complete reference for the PAM Backend API endpoints, authentication, and integr
 
 ## Base Information
 
-**Base URL**: `https://pam-backend.render.com/api` (Production)  
+**Base URL**: `https://pam-backend.onrender.com/api` (Production)
 **Local Development**: `http://localhost:8000/api`  
 **API Version**: v1  
 **Content-Type**: `application/json`  
@@ -98,10 +98,10 @@ Comprehensive health check with system metrics.
 
 ## WebSocket Endpoints
 
-### WebSocket /ws/{user_id}
+### WebSocket `/api/v1/pam/ws`
 Real-time WebSocket connection for PAM AI assistant communication.
 
-**Connection URL**: `wss://pam-backend.onrender.com/ws/{user_id}?token={jwt_token}`
+**Connection URL**: `wss://pam-backend.onrender.com/api/v1/pam/ws?token={jwt_token}`
 
 **Authentication**: JWT token in URL parameter
 
@@ -654,7 +654,7 @@ class PAMClient {
 }
 
 // Usage
-const client = new PAMClient('https://pam-backend.render.com/api', 'your_jwt_token');
+const client = new PAMClient('https://pam-backend.onrender.com/api', 'your_jwt_token');
 const expenses = await client.get('/expenses');
 ```
 
@@ -679,7 +679,7 @@ class PAMClient:
         return response.json()
 
 # Usage
-client = PAMClient('https://pam-backend.render.com/api', 'your_jwt_token')
+client = PAMClient('https://pam-backend.onrender.com/api', 'your_jwt_token')
 expenses = client.get('/expenses')
 ```
 

--- a/docs/technical/pam-backend-deployment.md
+++ b/docs/technical/pam-backend-deployment.md
@@ -85,7 +85,7 @@ python-multipart==0.0.18
 ### 1. **Deployment Success**
 - **Status**: PAM backend is successfully deployed and operational
 - **Service URL**: `https://pam-backend.onrender.com` ✅ ACCESSIBLE
-- **WebSocket Endpoint**: `wss://pam-backend.onrender.com/ws/{userId}` ✅ FUNCTIONAL
+- **WebSocket Endpoint**: `wss://pam-backend.onrender.com/api/v1/pam/ws` ✅ FUNCTIONAL
 - **Health Check**: `/api/health` endpoint responding correctly
 
 ### 2. **Active Features**

--- a/docs/technical/websocket-architecture.md
+++ b/docs/technical/websocket-architecture.md
@@ -274,7 +274,7 @@ const connectionMetrics = {
 
 3. **Test WebSocket Endpoint**
    ```javascript
-   const testWs = new WebSocket('wss://pam-backend.onrender.com/ws/test-user?token=demo-token');
+   const testWs = new WebSocket('wss://pam-backend.onrender.com/api/v1/pam/ws?token=demo-token');
    testWs.onopen = () => console.log('Test connection successful');
    testWs.onerror = (error) => console.error('Test connection failed:', error);
    ```


### PR DESCRIPTION
## Summary
- correct frontend directory name in setup guide
- update backend URL references to use `pam-backend.onrender.com`
- fix websocket endpoint paths across docs

## Testing
- `npm test` *(fails: useAuth must be used within an AuthProvider)*

------
https://chatgpt.com/codex/tasks/task_e_687229bbfafc8323b3c784060f9dd119