### PR TITLE
Fix Actions API path mismatch

### DIFF
--- a/backup/main_2025-07-05_01-08-39.bak
+++ b/backup/main_2025-07-05_01-08-39.bak
@@ -90,7 +90,7 @@ async def root():
         ],
         "api_endpoints": {
             "💬 chat": "/api/chat/message - Main conversation interface",
-            "🎮 actions": "/api/actions/execute - UI control commands",
+            "🎮 actions": "/api/execute - UI control commands",
             "💰 wins": "/api/wins/* - Financial management endpoints",
             "🚗 wheels": "/api/wheels/* - Travel and vehicle endpoints", 
             "👥 social": "/api/social/* - Community and marketplace endpoints",

--- a/src/components/Pam.tsx
+++ b/src/components/Pam.tsx
@@ -107,7 +107,7 @@ const Pam: React.FC<PamProps> = ({ mode = "floating" }) => {
 
   const saveToMemory = async (message: string, sender: 'user' | 'pam', context?: any) => {
     try {
-      await apiFetch('/api/actions/execute', {
+      await apiFetch('/api/execute', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- correct Actions endpoint in Pam.tsx
- update backup endpoint doc

## Testing
- `npm test` *(fails: 7 failed, 87 passed)*
- `pytest -q` *(fails: ImportError: cannot import name 'Undefined' from 'pydantic.fields')*

------
https://chatgpt.com/codex/tasks/task_e_687351d9c6408323b546378e0bb31996