### PR TITLE
Use env vars for Supabase client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # Copy this file to .env and fill in your own values
 
 # Supabase configuration
-# Client-side credentials for the Supabase project
+# Client-side credentials for the Supabase project (used in `client.ts`)
 VITE_SUPABASE_URL=http://localhost:54321
 VITE_SUPABASE_ANON_KEY=dev-anon-key
 

--- a/docs/features/authentication-system.md
+++ b/docs/features/authentication-system.md
@@ -80,8 +80,8 @@ PAM uses Supabase Auth for user authentication with support for multiple authent
 ## Configuration
 
 ### Environment Variables
-- `SUPABASE_URL` - Supabase project URL
-- `SUPABASE_ANON_KEY` - Supabase anonymous key
+- `VITE_SUPABASE_URL` - Supabase project URL
+- `VITE_SUPABASE_ANON_KEY` - Supabase anonymous key
 
 ### Security Settings
 - JWT expiration time

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -1,11 +1,9 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-// Use direct URLs instead of environment variables for Lovable
-const SUPABASE_URL = "https://kycoklimpzkyrecbjecn.supabase.co";
-const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imt5Y29rbGltcHpreXJlY2JqZWNuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDYyNTU4MDAsImV4cCI6MjA2MTgzMTgwMH0.nRZhYxImQ0rOlh0xZjHcdVq2Q2NY0v-9W3wciaxV2EA";
-
-// URLs are directly configured for Lovable deployment
+// Supabase credentials are loaded from Vite environment variables
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 // Create the supabase client with mobile optimizations
 export const supabase = createClient<Database>(


### PR DESCRIPTION
## Summary
- load Supabase credentials from `import.meta.env`
- document the Vite variables in `.env.example`
- update authentication docs for new variable names

## Testing
- `npm test` *(fails: Test Files 7 failed | 8 passed)*
- `pytest` *(fails to import pydantic_settings)*

------
https://chatgpt.com/codex/tasks/task_e_687356511fb48323a4156ec6b8f7f74d