### PR TITLE
Fix verify_supabase_jwt_token usage

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -436,7 +436,7 @@ async def get_current_user_optional(
     
     try:
         # Verify JWT token
-        payload = await verify_supabase_jwt_token(credentials)
+        payload = verify_supabase_jwt_token(credentials)
         db = DatabaseService()
         return await get_current_user(payload, db)
     except Exception:

--- a/tests/test_pam.py
+++ b/tests/test_pam.py
@@ -2,6 +2,7 @@ import os
 import sys
 from pathlib import Path
 import pytest
+import pytest_asyncio
 from httpx import AsyncClient
 
 # Ensure backend package is importable
@@ -15,7 +16,7 @@ from app.main import app
 if os.getenv("RUN_API_TESTS") != "1":
     pytest.skip("Skipping API tests", allow_module_level=True)
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def test_client() -> AsyncClient:
     async with AsyncClient(app=app, base_url="http://test") as client:
         yield client

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import base64
+from pathlib import Path
+from fastapi.testclient import TestClient
+import pytest
+
+# Ensure backend package is importable
+backend_path = Path(__file__).resolve().parent.parent / "backend"
+if str(backend_path) not in sys.path:
+    sys.path.insert(0, str(backend_path))
+
+# Provide minimal settings for FastAPI app
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("SUPABASE_KEY", "key")
+os.environ.setdefault("SUPABASE_URL", "https://example.supabase.co")
+os.environ.setdefault("OPENAI_API_KEY", "dummy")
+
+from app.main import app
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+def test_analyze_screenshot_no_typeerror(client):
+    img_data = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAJ+8CbkAAAAASUVORK5CYII="
+    )
+    files = {"image": ("test.png", img_data, "image/png")}
+    response = client.post(
+        "/api/v1/vision/analyze-screenshot",
+        files=files,
+        headers={"Authorization": "Bearer invalid"},
+    )
+    assert response.status_code >= 400
+    assert "object dict" not in response.text.lower()


### PR DESCRIPTION
## Summary
- remove erroneous await when verifying Supabase JWTs
- adjust `test_pam` fixture to use `pytest_asyncio`
- add regression test for vision screenshot endpoint

## Testing
- `pytest tests/test_vision.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6873593fba18832392d555bec897ac84