### PR TITLE
Add AssemblyAI transcription service

### DIFF
--- a/backend/app/services/transcription/__init__.py
+++ b/backend/app/services/transcription/__init__.py
@@ -1,0 +1,5 @@
+"""Transcription service package."""
+
+from .transcription_service import TranscriptionService, TranscriptionResult, transcription_service
+
+__all__ = ["TranscriptionService", "TranscriptionResult", "transcription_service"]

--- a/backend/app/services/transcription/transcription_service.py
+++ b/backend/app/services/transcription/transcription_service.py
@@ -1,0 +1,124 @@
+"""Media transcription service using AssemblyAI."""
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from app.core.config import get_settings
+from app.services.database import DatabaseService
+from app.api.editing_hub import hub
+
+settings = get_settings()
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TranscriptionResult:
+    """Container for transcription output."""
+
+    text: str
+    segments: List[Dict[str, Any]]
+
+
+class TranscriptionService:
+    """Service for transcribing media files with progress updates."""
+
+    def __init__(
+        self,
+        http_client: Optional[httpx.AsyncClient] = None,
+        db: Optional[DatabaseService] = None,
+    ) -> None:
+        self.http_client = http_client or httpx.AsyncClient()
+        self.db = db or DatabaseService()
+        self.api_key = getattr(settings, "ASSEMBLYAI_API_KEY", None)
+        self.base_url = "https://api.assemblyai.com/v2"
+
+    async def _upload_to_assemblyai(self, file_path: str) -> str:
+        headers = {"authorization": self.api_key}
+        with open(file_path, "rb") as f:
+            response = await self.http_client.post(
+                f"{self.base_url}/upload", data=f, headers=headers
+            )
+        response.raise_for_status()
+        return response.json()["upload_url"]
+
+    async def _start_transcription(self, upload_url: str) -> str:
+        headers = {
+            "authorization": self.api_key,
+            "content-type": "application/json",
+        }
+        payload = {"audio_url": upload_url, "speaker_labels": True}
+        response = await self.http_client.post(
+            f"{self.base_url}/transcript", json=payload, headers=headers
+        )
+        response.raise_for_status()
+        return response.json()["id"]
+
+    async def _get_transcript(self, transcript_id: str) -> Dict[str, Any]:
+        headers = {"authorization": self.api_key}
+        response = await self.http_client.get(
+            f"{self.base_url}/transcript/{transcript_id}", headers=headers
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def _store_result(self, file_id: str, result: TranscriptionResult) -> None:
+        if not self.db.client:
+            return
+        try:
+            self.db.client.table("media_transcripts").insert(
+                {
+                    "file_id": file_id,
+                    "text": result.text,
+                    "segments": result.segments,
+                    "created_at": datetime.utcnow().isoformat(),
+                }
+            ).execute()
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.warning(f"Failed to store transcript: {exc}")
+
+    async def transcribe_media(
+        self, file_path: str, file_id: str, websocket: Optional[Any] = None
+    ) -> TranscriptionResult:
+        """Transcribe media file and stream progress."""
+        if not self.api_key:
+            raise RuntimeError("ASSEMBLYAI_API_KEY not configured")
+
+        upload_url = await self._upload_to_assemblyai(file_path)
+        transcript_id = await self._start_transcription(upload_url)
+
+        while True:
+            status = await self._get_transcript(transcript_id)
+            progress = status.get("words", [])
+            percent = 0
+            if status["status"] == "completed":
+                percent = 100
+            elif progress:
+                percent = min(int(len(progress) / max(status.get("word_count", 1), 1) * 100), 99)
+
+            if websocket is not None:
+                await hub.send_progress(
+                    websocket,
+                    "TranscriptionProgress",
+                    percent,
+                    status.get("status", "queued"),
+                )
+
+            if status["status"] == "completed":
+                text = status.get("text", "")
+                segments = status.get("utterances", []) or []
+                result = TranscriptionResult(text=text, segments=segments)
+                await self._store_result(file_id, result)
+                return result
+
+            if status["status"] == "error":
+                raise RuntimeError(status.get("error", "Unknown error"))
+
+            await asyncio.sleep(1)
+
+
+transcription_service = TranscriptionService()

--- a/backend/requirements.full.txt
+++ b/backend/requirements.full.txt
@@ -97,6 +97,7 @@ scikit-learn>=1.5.0
 
 # Enhanced Web Scraping and APIs - SECURITY FIX: Updated requests to fix credential leak vulnerability
 requests>=2.32.0
+assemblyai==0.42.0
 aiofiles==23.2.1
 googlemaps==4.10.0
 yelpapi==2.5.0

--- a/backend/requirements.minimal.txt
+++ b/backend/requirements.minimal.txt
@@ -27,6 +27,7 @@ httpx==0.27.0
 # Web scraping (basic) - SECURITY FIX: Updated requests to fix credential leak vulnerability
 beautifulsoup4==4.12.3
 requests>=2.32.0
+assemblyai==0.42.0
 
 # Logging
 structlog==23.2.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,6 +7,7 @@ beautifulsoup4==4.12.3
 psutil==5.9.8
 prometheus-client==0.19.0
 tiktoken>=0.8.0
+assemblyai==0.42.0
 
 # OpenTelemetry for observability (stable versions)
 opentelemetry-api>=1.20.0

--- a/backend/tests/unit/test_transcription_service.py
+++ b/backend/tests/unit/test_transcription_service.py
@@ -1,0 +1,22 @@
+import pytest
+from unittest.mock import patch
+
+from app.services.transcription import TranscriptionService, TranscriptionResult
+
+
+@pytest.mark.asyncio
+async def test_transcribe_media_success():
+    service = TranscriptionService()
+    service.api_key = "test"
+    with patch.object(service, '_upload_to_assemblyai', return_value='upload'), \
+         patch.object(service, '_start_transcription', return_value='id'), \
+         patch.object(service, '_store_result', return_value=None), \
+         patch.object(service, '_get_transcript', side_effect=[
+             {'status': 'processing', 'words': [1], 'word_count': 10},
+             {'status': 'completed', 'text': 'hello', 'utterances': [], 'words': [1]*10, 'word_count': 10}
+         ]):
+
+        result = await service.transcribe_media('file.wav', 'file1')
+
+    assert isinstance(result, TranscriptionResult)
+    assert result.text == 'hello'


### PR DESCRIPTION
## Summary
- implement `TranscriptionService` for AssemblyAI
- save transcripts to DB if configured
- add accompanying unit test
- pin `assemblyai` dependency in backend requirements

## Testing
- `pytest backend/tests/unit/test_transcription_service.py -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6878e0ec54108323a8bbbb6a61210afa