### PR TITLE
Implement content matcher

### DIFF
--- a/backend/app/services/content_matching/__init__.py
+++ b/backend/app/services/content_matching/__init__.py
@@ -1,0 +1,1 @@
+from .content_matcher import ContentMatcher, MediaMatch, TranscribedMedia, TranscribedSegment

--- a/backend/app/services/content_matching/content_matcher.py
+++ b/backend/app/services/content_matching/content_matcher.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+from app.services.script_analysis.openai_script_analyzer import ScriptAnalysis
+
+
+@dataclass
+class MatchResult:
+    file_id: str
+    start_time: float
+    end_time: float
+    score: float
+
+
+class MediaMatch(BaseModel):
+    segment_id: str
+    media_file_id: str
+    start_time: float
+    end_time: float
+    confidence: float
+
+
+class TranscribedSegment(BaseModel):
+    text: str
+    start: float
+    end: float
+    speaker: Optional[str] = None
+
+
+class TranscribedMedia(BaseModel):
+    file_id: str
+    filename: Optional[str] = None
+    segments: List[TranscribedSegment]
+
+
+class ContentMatcher:
+    """Match script segments to transcribed media."""
+
+    @staticmethod
+    def _normalize(text: str) -> str:
+        return re.sub(r"\W+", " ", text).lower().strip()
+
+    @staticmethod
+    def _levenshtein(a: str, b: str) -> int:
+        if a == b:
+            return 0
+        if not a:
+            return len(b)
+        if not b:
+            return len(a)
+        prev_row = list(range(len(b) + 1))
+        for i, ca in enumerate(a, 1):
+            row = [i]
+            for j, cb in enumerate(b, 1):
+                insertions = prev_row[j] + 1
+                deletions = row[j - 1] + 1
+                substitutions = prev_row[j - 1] + (ca != cb)
+                row.append(min(insertions, deletions, substitutions))
+            prev_row = row
+        return prev_row[-1]
+
+    def _similarity(self, a: str, b: str) -> float:
+        a_norm = self._normalize(a)
+        b_norm = self._normalize(b)
+        dist = self._levenshtein(a_norm, b_norm)
+        max_len = max(len(a_norm), len(b_norm)) or 1
+        return 1 - dist / max_len
+
+    def _find_best_quote_match(
+        self,
+        quote: str,
+        media_files: List[TranscribedMedia],
+        threshold: float = 0.85,
+        speaker: Optional[str] = None,
+    ) -> Optional[MatchResult]:
+        best: Optional[MatchResult] = None
+        best_score = threshold
+        for media in media_files:
+            for seg in media.segments:
+                if speaker and seg.speaker and seg.speaker.lower() != speaker.lower():
+                    continue
+                score = self._similarity(quote, seg.text)
+                if score >= best_score:
+                    best = MatchResult(
+                        file_id=media.file_id,
+                        start_time=seg.start,
+                        end_time=seg.end,
+                        score=score,
+                    )
+                    best_score = score
+        return best
+
+    def _match_by_keywords(
+        self,
+        keywords: List[str],
+        media_files: List[TranscribedMedia],
+        segment_id: str,
+    ) -> List[MediaMatch]:
+        matches: List[MediaMatch] = []
+        if not keywords:
+            return matches
+        for media in media_files:
+            name = (media.filename or "").lower()
+            hits = sum(1 for k in keywords if k.lower() in name)
+            if hits:
+                score = hits / len(keywords)
+                matches.append(
+                    MediaMatch(
+                        segment_id=segment_id,
+                        media_file_id=media.file_id,
+                        start_time=0.0,
+                        end_time=0.0,
+                        confidence=score,
+                    )
+                )
+        return matches
+
+    async def match_content_to_script(
+        self,
+        script: ScriptAnalysis,
+        media_files: List[TranscribedMedia],
+    ) -> List[MediaMatch]:
+        matches: List[MediaMatch] = []
+        for idx, segment in enumerate(script.segments):
+            seg_id = str(idx)
+            if segment.type == "soundbite" and segment.quote:
+                match = self._find_best_quote_match(
+                    segment.quote,
+                    media_files,
+                    threshold=0.85,
+                    speaker=segment.speaker,
+                )
+                if match:
+                    matches.append(
+                        MediaMatch(
+                            segment_id=seg_id,
+                            media_file_id=match.file_id,
+                            start_time=match.start_time,
+                            end_time=match.end_time,
+                            confidence=match.score,
+                        )
+                    )
+            elif segment.type == "broll":
+                matches.extend(
+                    self._match_by_keywords(
+                        segment.keywords or [],
+                        media_files,
+                        seg_id,
+                    )
+                )
+        return matches

--- a/backend/tests/unit/test_content_matcher.py
+++ b/backend/tests/unit/test_content_matcher.py
@@ -1,0 +1,39 @@
+import pytest
+from app.services.content_matching import ContentMatcher, TranscribedMedia, TranscribedSegment
+from app.services.script_analysis.openai_script_analyzer import ScriptAnalysis, ScriptSegment
+
+
+@pytest.mark.asyncio
+async def test_match_soundbite():
+    matcher = ContentMatcher()
+    script = ScriptAnalysis(
+        segments=[ScriptSegment(type="soundbite", speaker="John", quote="we will win", duration=3)],
+        totalDuration=3,
+    )
+    media = [
+        TranscribedMedia(
+            file_id="f1",
+            filename="john.mp4",
+            segments=[TranscribedSegment(text="We will win", start=0.0, end=1.0, speaker="John")],
+        )
+    ]
+    matches = await matcher.match_content_to_script(script, media)
+    assert len(matches) == 1
+    match = matches[0]
+    assert match.segment_id == "0"
+    assert match.media_file_id == "f1"
+    assert match.start_time == 0.0
+
+
+@pytest.mark.asyncio
+async def test_match_broll_by_keywords():
+    matcher = ContentMatcher()
+    script = ScriptAnalysis(
+        segments=[ScriptSegment(type="broll", keywords=["beach"], duration=4)],
+        totalDuration=4,
+    )
+    media = [TranscribedMedia(file_id="b1", filename="sunny_beach.mp4", segments=[])]
+    matches = await matcher.match_content_to_script(script, media)
+    assert len(matches) == 1
+    assert matches[0].media_file_id == "b1"
+

--- a/src/__tests__/components/ContentMatchFallback.test.tsx
+++ b/src/__tests__/components/ContentMatchFallback.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import ContentMatchFallback, { CandidateMatch } from '../../components/ContentMatchFallback';
+
+describe('ContentMatchFallback', () => {
+  it('allows manual selection of candidates', () => {
+    const candidates: CandidateMatch[] = [
+      { fileId: '1', fileName: 'a.mp4', score: 0.9 },
+      { fileId: '2', fileName: 'b.mp4', score: 0.8 },
+    ];
+    const onSelect = vi.fn();
+    render(<ContentMatchFallback candidates={candidates} onSelect={onSelect} />);
+    const option = screen.getByLabelText(/a.mp4/i);
+    fireEvent.click(option);
+    fireEvent.click(screen.getByRole('button', { name: /select/i }));
+    expect(onSelect).toHaveBeenCalledWith(candidates[0]);
+  });
+});

--- a/src/components/ContentMatchFallback.tsx
+++ b/src/components/ContentMatchFallback.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { Card, CardContent, CardFooter, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
+export interface CandidateMatch {
+  fileId: string;
+  fileName: string;
+  score: number;
+}
+
+interface Props {
+  candidates: CandidateMatch[];
+  onSelect: (match: CandidateMatch) => void;
+}
+
+export function ContentMatchFallback({ candidates, onSelect }: Props) {
+  const [selected, setSelected] = useState<CandidateMatch | null>(null);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Select Matching Media</CardTitle>
+        <CardDescription>
+          No automatic match found. Please choose the correct media file.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-2">
+          {candidates.map((c) => (
+            <li key={c.fileId}>
+              <label className="flex items-center space-x-2">
+                <input
+                  type="radio"
+                  name="match"
+                  value={c.fileId}
+                  onChange={() => setSelected(c)}
+                />
+                <span>
+                  {c.fileName} ({Math.round(c.score * 100)}%)
+                </span>
+              </label>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+      <CardFooter>
+        <Button disabled={!selected} onClick={() => selected && onSelect(selected)}>
+          Select
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}
+
+export default ContentMatchFallback;


### PR DESCRIPTION
## Summary
- add `ContentMatcher` service for matching script segments to media
- provide React `ContentMatchFallback` component for manual matches
- test new content matching logic and fallback UI

## Testing
- `npm test`
- `pytest` *(fails: ModuleNotFoundError for several packages)*

------
https://chatgpt.com/codex/tasks/task_e_6878e64ffe4483238135aeb533c4c7a4