### PR TITLE
Add broadcast export service

### DIFF
--- a/backend/dotnet/ExportService.cs
+++ b/backend/dotnet/ExportService.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace WheelsWins.Broadcast
+{
+    public class ExportSettings
+    {
+        public string Standard { get; set; }
+        public IList<string> Formats { get; set; } = new List<string>();
+        public DeliveryOptions Delivery { get; set; } = new DeliveryOptions();
+    }
+
+    public class DeliveryOptions
+    {
+        public bool LocalDownload { get; set; }
+        public FtpOptions? Ftp { get; set; }
+        public ApiOptions? Api { get; set; }
+        public CloudOptions? Cloud { get; set; }
+    }
+
+    public class FtpOptions
+    {
+        public string Host { get; set; } = string.Empty;
+        public string Username { get; set; } = string.Empty;
+        public string Password { get; set; } = string.Empty;
+        public string RemotePath { get; set; } = string.Empty;
+    }
+
+    public class ApiOptions
+    {
+        public string Endpoint { get; set; } = string.Empty;
+        public string ApiKey { get; set; } = string.Empty;
+    }
+
+    public class CloudOptions
+    {
+        public string Provider { get; set; } = string.Empty; // e.g. AWS, Azure
+        public string Container { get; set; } = string.Empty;
+    }
+
+    public class ComplianceReport
+    {
+        public bool IsValid { get; set; }
+        public IList<string> Issues { get; set; } = new List<string>();
+    }
+
+    public class ExportResult
+    {
+        public IDictionary<string, string> Files { get; set; } = new Dictionary<string, string>();
+        public ComplianceReport ComplianceReport { get; set; } = new ComplianceReport();
+    }
+
+    public class BroadcastComplianceException : Exception
+    {
+        public IList<string> Issues { get; }
+
+        public BroadcastComplianceException(IList<string> issues)
+            : base("Broadcast compliance failed")
+        {
+            Issues = issues;
+        }
+    }
+
+    public class ExportService
+    {
+        public async Task<ExportResult> ExportForBroadcast(string projectId, ExportSettings settings)
+        {
+            var project = await LoadProject(projectId);
+            var renderedVideo = project.RenderedPath;
+
+            // Apply broadcast standards
+            var processedVideo = await ApplyBroadcastStandards(renderedVideo, settings.Standard);
+
+            // Verify compliance
+            var compliance = await VerifyCompliance(processedVideo);
+            if (!compliance.IsValid)
+            {
+                throw new BroadcastComplianceException(compliance.Issues);
+            }
+
+            // Generate output formats
+            var outputs = new Dictionary<string, string>();
+
+            if (settings.Formats.Contains("MP4"))
+            {
+                outputs["MP4"] = await ConvertToMp4(processedVideo);
+            }
+
+            if (settings.Formats.Contains("MXF"))
+            {
+                outputs["MXF"] = await ConvertToMxf(processedVideo);
+            }
+
+            // Deliver outputs
+            await Deliver(outputs, settings.Delivery);
+
+            return new ExportResult
+            {
+                Files = outputs,
+                ComplianceReport = compliance
+            };
+        }
+
+        private Task<dynamic> LoadProject(string projectId)
+        {
+            // Placeholder for loading project details
+            return Task.FromResult<dynamic>(new { RenderedPath = $"{projectId}/render.mov" });
+        }
+
+        private Task<string> ApplyBroadcastStandards(string inputPath, string standard)
+        {
+            // Stub for processing video to meet broadcast standards like ATSC or EBU R128
+            return Task.FromResult(inputPath);
+        }
+
+        private Task<ComplianceReport> VerifyCompliance(string videoPath)
+        {
+            // Stub compliance check
+            return Task.FromResult(new ComplianceReport { IsValid = true });
+        }
+
+        private Task<string> ConvertToMp4(string inputPath)
+        {
+            // Placeholder for actual conversion logic
+            return Task.FromResult(inputPath.Replace(".mov", ".mp4"));
+        }
+
+        private Task<string> ConvertToMxf(string inputPath)
+        {
+            // Placeholder for actual conversion logic
+            return Task.FromResult(inputPath.Replace(".mov", ".mxf"));
+        }
+
+        private async Task Deliver(IDictionary<string, string> files, DeliveryOptions options)
+        {
+            if (options.LocalDownload)
+            {
+                await Task.Run(() => Console.WriteLine("Saved locally"));
+            }
+
+            if (options.Ftp != null)
+            {
+                await UploadViaFtp(files, options.Ftp);
+            }
+
+            if (options.Api != null)
+            {
+                await SendToNewsroomApi(files, options.Api);
+            }
+
+            if (options.Cloud != null)
+            {
+                await UploadToCloud(files, options.Cloud);
+            }
+        }
+
+        private Task UploadViaFtp(IDictionary<string, string> files, FtpOptions options)
+        {
+            // Stub FTP upload implementation
+            return Task.CompletedTask;
+        }
+
+        private Task SendToNewsroomApi(IDictionary<string, string> files, ApiOptions options)
+        {
+            // Stub API integration implementation
+            return Task.CompletedTask;
+        }
+
+        private Task UploadToCloud(IDictionary<string, string> files, CloudOptions options)
+        {
+            // Stub cloud upload implementation
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/docs/technical/broadcast-export-service.md
+++ b/docs/technical/broadcast-export-service.md
@@ -1,0 +1,16 @@
+# Broadcast Export Service
+
+This document describes the **ExportService** implemented in `backend/dotnet/ExportService.cs`.
+
+The service provides video export functionality suitable for broadcast environments. Key features include:
+
+- Applying broadcast standards such as ATSC or EBU R128 before export.
+- Verification of compliance with broadcast requirements.
+- Generation of multiple output formats (MP4 and MXF).
+- Delivery options for final files:
+  - Local download.
+  - FTP upload to a playout server.
+  - API integration with newsroom systems.
+  - Cloud storage upload (e.g., AWS or Azure).
+
+The implementation currently contains placeholders for the processing logic. Integrate real media processing tools and delivery SDKs as needed.


### PR DESCRIPTION
## Summary
- implement `ExportService` for broadcast compliance in C#
- document new broadcast export service

## Testing
- `npm test`
- `pip install -r backend/requirements-dev.txt` *(fails: resolution impossible)*
- `pytest` *(fails: ModuleNotFoundError: openai, websockets, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6878ee1644308323a9060bd938451755