### PR TITLE
Add configurable HTTP timeouts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,4 +20,8 @@ VITE_N8N_TRIP_WEBHOOK=https://treflip2025.app.n8n.cloud/webhook/4cd18979-6ee8-45
 # Mapbox public access token (should start with 'pk.')
 VITE_MAPBOX_TOKEN=pk.your_mapbox_token_here
 
+# Default timeouts (in seconds)
+HTTP_TIMEOUT=10
+VITE_FETCH_TIMEOUT=10000
+
 # Other environment variables can go here

--- a/src/__tests__/services/api.test.ts
+++ b/src/__tests__/services/api.test.ts
@@ -103,7 +103,7 @@ describe('API Service', () => {
 
       expect(mockFetch).toHaveBeenCalledWith(
         'https://pam-backend.onrender.com/public',
-        {}
+        expect.objectContaining({ signal: expect.any(Object) })
       );
     });
   });


### PR DESCRIPTION
## Summary
- add `HTTP_TIMEOUT` and `VITE_FETCH_TIMEOUT` env vars
- use configurable timeout in scraper and auth modules
- add `fetchWithTimeout` helper in frontend API service
- update API service tests

## Testing
- `npm test`
- `pytest -q` *(fails: ImportError due to incompatible dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6879dcb5d890832390cebcdc553572df