### PR TITLE
Fix async inconsistencies in API handlers

### DIFF
--- a/backend/app/api/actions.py
+++ b/backend/app/api/actions.py
@@ -21,7 +21,7 @@ class ActionResponse(BaseModel):
     message: str
 
 @router.post("/execute", response_model=ActionResponse)
-async def execute_action(request: ActionRequest):
+def execute_action(request: ActionRequest):
     """Execute a specific action based on the request"""
     try:
         action_type = request.action  # Use action field
@@ -86,7 +86,7 @@ async def execute_action(request: ActionRequest):
         raise HTTPException(status_code=500, detail=str(e))
 
 @router.get("/available")
-async def get_available_actions():
+def get_available_actions():
     """Get list of available actions"""
     return {
         "actions": [
@@ -114,7 +114,7 @@ async def get_available_actions():
     }
 
 @router.get("/status")
-async def get_action_status():
+def get_action_status():
     """Get the status of the actions service"""
     return {
         "status": "operational",
@@ -123,7 +123,7 @@ async def get_action_status():
     }
 
 @router.post("/test")
-async def test_actions():
+def test_actions():
     """Test endpoint to verify actions API is working"""
     logger.info("🧪 Actions test endpoint called")
     return {

--- a/backend/app/api/social.py
+++ b/backend/app/api/social.py
@@ -3,5 +3,5 @@ from fastapi import APIRouter
 router = APIRouter()
 
 @router.get("/status")
-async def get_status():
+def get_status():
     return {"status": "social module operational"}

--- a/backend/fix_social_frontend.py
+++ b/backend/fix_social_frontend.py
@@ -31,7 +31,7 @@ router = APIRouter()
 logger = get_logger(__name__)
 
 @router.get("/social/feed")
-async def get_social_feed(
+def get_social_feed(
     location: str = "feed",
     current_user: UnifiedUser = Depends(get_current_user_unified)
 ):
@@ -97,7 +97,7 @@ async def get_social_feed(
         }
 
 @router.post("/social/posts")
-async def create_social_post(
+def create_social_post(
     post_data: Dict[str, Any],
     current_user: UnifiedUser = Depends(get_current_user_unified)
 ):
@@ -141,7 +141,7 @@ async def create_social_post(
         }
 
 @router.get("/social/groups")
-async def get_social_groups(
+def get_social_groups(
     current_user: UnifiedUser = Depends(get_current_user_unified)
 ):
     """Get social groups"""


### PR DESCRIPTION
## Summary
- refactor API endpoints to use synchronous functions where no await is needed
- update social frontend fix

## Testing
- `npm test --silent`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6879de64ad40832394b6e03d28d68fe1