### PR TITLE
Add math utility module and tests

### DIFF
--- a/backend/app/utils/math_utils.py
+++ b/backend/app/utils/math_utils.py
@@ -1,0 +1,31 @@
+"""Basic arithmetic utility functions."""
+
+from __future__ import annotations
+
+
+def add(a: float, b: float) -> float:
+    """Return the sum of ``a`` and ``b``."""
+    return a + b
+
+
+def subtract(a: float, b: float) -> float:
+    """Return the difference of ``a`` and ``b``."""
+    return a - b
+
+
+def multiply(a: float, b: float) -> float:
+    """Return the product of ``a`` and ``b``."""
+    return a * b
+
+
+def divide(a: float, b: float) -> float:
+    """Return the quotient of ``a`` and ``b``.
+
+    Raises
+    ------
+    ValueError
+        If ``b`` is ``0``.
+    """
+    if b == 0:
+        raise ValueError("Cannot divide by zero")
+    return a / b

--- a/simple_tests/test_math_utils.py
+++ b/simple_tests/test_math_utils.py
@@ -1,0 +1,35 @@
+import pytest
+
+from app.utils.math_utils import add, subtract, multiply, divide
+
+@pytest.mark.parametrize("a,b,expected", [
+    (1, 2, 3),
+    (-1, -1, -2),
+    (0, 5, 5),
+])
+def test_add(a, b, expected):
+    assert add(a, b) == expected
+
+
+@pytest.mark.parametrize("a,b,expected", [
+    (5, 2, 3),
+    (-1, -1, 0),
+    (0, 5, -5),
+])
+def test_subtract(a, b, expected):
+    assert subtract(a, b) == expected
+
+
+@pytest.mark.parametrize("a,b,expected", [
+    (2, 3, 6),
+    (-1, 5, -5),
+    (0, 5, 0),
+])
+def test_multiply(a, b, expected):
+    assert multiply(a, b) == expected
+
+
+def test_divide():
+    assert divide(10, 2) == 5
+    with pytest.raises(ValueError):
+        divide(1, 0)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,12 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
+      include: [
+        'src/components/**/*.{ts,tsx}',
+        'src/lib/**/*.{ts,tsx}',
+        'src/services/**/*.{ts,tsx}',
+        'src/context/**/*.{ts,tsx}'
+      ],
       exclude: [
         'node_modules/',
         'src/test/',


### PR DESCRIPTION
## Summary
- add simple math utilities module
- add pytest unit tests for math utilities
- narrow vitest coverage include patterns

## Testing
- `PYTHONPATH=backend pytest simple_tests/test_math_utils.py --cov=app.utils.math_utils --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_6879ead205dc8323a157c02a6480776c