### PR TITLE
Enable OpenTelemetry tracing

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -13,7 +13,7 @@ class Settings(BaseSettings):
     ENVIRONMENT: str = "production"  # Changed to production for deployed instances
     DEBUG: bool = False
     VERSION: str = "2.0.0"
-    
+
     # Debug Features Control (only enabled in development)
     ENABLE_DEBUG_FEATURES: bool = False
     SHOW_DEBUG_TOKENS: bool = False
@@ -43,23 +43,25 @@ class Settings(BaseSettings):
     SUPABASE_SERVICE_ROLE_KEY: Optional[str] = None
     SITE_URL: str = "http://localhost:3000"
     MUNDI_URL: Optional[str] = None
-    
+
     # Search APIs
     GOOGLE_SEARCH_API_KEY: Optional[str] = None
     GOOGLE_SEARCH_ENGINE_ID: Optional[str] = None
     BING_SEARCH_API_KEY: Optional[str] = None
-    
+
     # AI Agent Observability
     LANGFUSE_SECRET_KEY: Optional[str] = None
     LANGFUSE_PUBLIC_KEY: Optional[str] = None
     LANGFUSE_HOST: str = "https://cloud.langfuse.com"
     AGENTOPS_API_KEY: Optional[str] = None
     OBSERVABILITY_ENABLED: bool = True
+    OTLP_ENDPOINT: Optional[str] = None
+    OTLP_API_KEY: Optional[str] = None
 
     # CORS - Allow requests from development and production origins
     CORS_ORIGINS: List[str] = [
         "http://localhost:3000",
-        "http://localhost:8080", 
+        "http://localhost:8080",
         "http://localhost:5173",
         "https://wheelsandwins.com",
         "https://www.wheelsandwins.com",
@@ -101,7 +103,9 @@ class Settings(BaseSettings):
         """Load settings and handle missing required environment variables."""
         try:
             return cls()
-        except ValidationError as exc:  # pragma: no cover - runtime configuration failure
+        except (
+            ValidationError
+        ) as exc:  # pragma: no cover - runtime configuration failure
             missing = ", ".join(err["loc"][0] for err in exc.errors())
             raise RuntimeError(f"Missing required settings: {missing}") from exc
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,10 +20,12 @@ from app.core.middleware import setup_middleware
 from app.core.security_middleware import setup_security_middleware
 from app.core.monitoring_middleware import MonitoringMiddleware
 from app.guardrails.guardrails_middleware import GuardrailsMiddleware
+
 # Temporarily disabled due to WebSocket route conflicts
 # from langserve import add_routes
 # from app.services.pam.mcp.controllers.pauter_router import PauterRouter
 from app.voice.stt_whisper import whisper_stt
+
 # from app.voice.tts_coqui import coqui_tts  # Temporarily disabled due to TTS dependency issues
 from app.core.config import settings
 from app.core.logging import setup_logging, get_logger
@@ -33,7 +35,23 @@ from app.services.monitoring_service import monitoring_service
 from app.services.sentry_service import sentry_service
 
 # Import API routers
-from app.api.v1 import health, chat, wins, wheels, social, monitoring, pam, auth, subscription, support, admin, observability, tts, search, vision
+from app.api.v1 import (
+    health,
+    chat,
+    wins,
+    wheels,
+    social,
+    monitoring,
+    pam,
+    auth,
+    subscription,
+    support,
+    admin,
+    observability,
+    tts,
+    search,
+    vision,
+)
 from app.api import websocket, actions
 from app.api.v1 import voice_streaming
 from app.api import editing_hub
@@ -47,82 +65,88 @@ logger.info(f"CORS_ORIGINS from settings: {settings.CORS_ORIGINS}")
 logger.info(f"ALLOWED_ORIGINS env var: {os.getenv('ALLOWED_ORIGINS')}")
 logger.info(f"CORS_ORIGINS env var: {os.getenv('CORS_ORIGINS')}")
 
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Application lifespan manager with monitoring initialization"""
     logger.info("🚀 Starting PAM Backend with monitoring and security...")
-    
+
     # Initialize monitoring services
     try:
         # Initialize Sentry first
         sentry_service.initialize()
         logger.info("✅ Sentry error tracking initialized")
-        
+
         # Initialize performance components
         # Note: Database pool disabled - using Supabase REST API instead
         # await db_pool.initialize()
         logger.info("✅ Database access via Supabase REST API")
-        
+
         await cache_service.initialize()
         logger.info("✅ Redis cache service initialized")
-        
+
         # Initialize Knowledge Tool for PAM
         try:
             from app.core.orchestrator import orchestrator
+
             await orchestrator.initialize_knowledge_tool()
             logger.info("✅ PAM Knowledge Tool initialized")
         except Exception as e:
             logger.warning(f"⚠️ Knowledge Tool initialization failed: {e}")
-        
+
         # Initialize TTS Service for PAM
         try:
             from app.services.tts.tts_service import tts_service
+
             await tts_service.initialize()
             logger.info("✅ PAM TTS Service initialized")
         except Exception as e:
             logger.warning(f"⚠️ TTS Service initialization failed: {e}")
-        
+
         logger.info("✅ WebSocket manager ready")
         logger.info("✅ Monitoring service ready")
-        
+
         logger.info("🎯 All performance optimizations active")
         logger.info("🔒 Security hardening measures active")
         logger.info("📊 Monitoring and alerting active")
-        
+
     except Exception as e:
         logger.error(f"❌ Failed to initialize components: {e}")
         sentry_service.capture_exception(e)
         raise
-    
+
     yield
-    
+
     # Cleanup on shutdown
     logger.info("🔄 Shutting down PAM Backend...")
-    
+
     try:
         # await db_pool.close()  # Database pool disabled
         await cache_service.close()
-        
+
         # Shutdown Knowledge Tool
         try:
             from app.tools.knowledge_tool import knowledge_tool
+
             await knowledge_tool.shutdown()
             logger.info("✅ Knowledge Tool shutdown completed")
         except Exception as e:
             logger.warning(f"⚠️ Knowledge Tool shutdown warning: {e}")
-        
+
         # Shutdown TTS Service
         try:
             from app.services.tts.tts_service import tts_service
+
             await tts_service.shutdown()
             logger.info("✅ TTS Service shutdown completed")
         except Exception as e:
             logger.warning(f"⚠️ TTS Service shutdown warning: {e}")
-        
+
         logger.info("✅ Cleanup completed")
     except Exception as e:
         logger.error(f"❌ Error during cleanup: {e}")
         sentry_service.capture_exception(e)
+
 
 # Create FastAPI app
 app = FastAPI(
@@ -131,8 +155,23 @@ app = FastAPI(
     version="2.0.0",
     lifespan=lifespan,
     docs_url="/api/docs" if settings.ENVIRONMENT != "production" else None,
-    redoc_url="/api/redoc" if settings.ENVIRONMENT != "production" else None
+    redoc_url="/api/redoc" if settings.ENVIRONMENT != "production" else None,
 )
+
+# Enable distributed tracing with OpenTelemetry if available
+try:
+    from app.observability.config import observability, OPENTELEMETRY_AVAILABLE
+    from opentelemetry import trace
+    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+    if OPENTELEMETRY_AVAILABLE and observability.is_enabled():
+        observability.initialize_tracing()
+        FastAPIInstrumentor().instrument_app(
+            app, tracer_provider=trace.get_tracer_provider()
+        )
+        logger.info("✅ OpenTelemetry FastAPI instrumentation enabled")
+except Exception as trace_error:
+    logger.warning(f"OpenTelemetry instrumentation failed: {trace_error}")
 
 # Setup middleware
 app.add_middleware(MonitoringMiddleware)
@@ -145,7 +184,7 @@ app.add_middleware(GuardrailsMiddleware)
 cors_origins = [
     "*",  # Temporarily allow all origins for debugging
     "http://localhost:3000",
-    "http://localhost:8080", 
+    "http://localhost:8080",
     "http://localhost:5173",
     "https://wheelsandwins.com",
     "https://www.wheelsandwins.com",
@@ -169,6 +208,7 @@ app.add_middleware(
 # CORS middleware handles OPTIONS requests automatically
 # No custom OPTIONS handler needed
 
+
 # Add root route handler
 @app.get("/")
 async def root():
@@ -176,14 +216,17 @@ async def root():
     return {
         "message": "🤖 PAM Backend API",
         "version": "2.0.1",
-        "status": "operational", 
+        "status": "operational",
         "docs": "/api/docs",
         "health": "/health",
-        "updated": "2025-07-10T06:45:00Z"
+        "updated": "2025-07-10T06:45:00Z",
     }
 
+
 # Include API routers
-app.include_router(health.router, prefix="", tags=["Health"])  # No prefix for /health endpoint
+app.include_router(
+    health.router, prefix="", tags=["Health"]
+)  # No prefix for /health endpoint
 app.include_router(monitoring.router, prefix="/api", tags=["Monitoring"])
 app.include_router(chat.router, prefix="/api", tags=["Chat"])
 app.include_router(wins.router, prefix="/api", tags=["Wins"])
@@ -201,7 +244,9 @@ app.include_router(observability.router, prefix="/api/v1", tags=["Admin Observab
 app.include_router(tts.router, prefix="/api/v1/tts", tags=["Text-to-Speech"])
 # Mundi integration removed
 app.include_router(actions.router, prefix="/api", tags=["Actions"])
-app.include_router(voice_streaming.router, prefix="/api/v1/voice", tags=["Voice Streaming"])
+app.include_router(
+    voice_streaming.router, prefix="/api/v1/voice", tags=["Voice Streaming"]
+)
 app.include_router(search.router, prefix="/api/v1/search", tags=["Web Search"])
 app.include_router(vision.router, prefix="/api/v1/vision", tags=["Vision Analysis"])
 app.include_router(editing_hub.router, prefix="/hubs", tags=["Editing"])
@@ -220,34 +265,35 @@ async def pam_voice(audio: UploadFile = File(...)):
         audio_data = await audio.read()
         text = await whisper_stt.transcribe(audio_data)
         logger.info(f"📝 Transcribed: {text}")
-        
+
         if not text or text.strip() == "":
             return {"error": "No speech detected", "text": "", "response": ""}
-        
+
         # Step 2: LLM Processing through PAM Orchestrator
         logger.info("🧠 Processing through PAM...")
         from app.services.pam.orchestrator import get_orchestrator
+
         orchestrator = await get_orchestrator()
-        
+
         # Create a simple context for voice input
         voice_context = {
             "input_type": "voice",
             "user_id": "voice-user",  # In production, extract from auth
             "session_id": "voice-session",
-            "timestamp": str(datetime.utcnow())
+            "timestamp": str(datetime.utcnow()),
         }
-        
+
         # Process message through PAM
         pam_response = await orchestrator.process_message(
             user_id="voice-user",
             message=text,
-            session_id="voice-session", 
-            context=voice_context
+            session_id="voice-session",
+            context=voice_context,
         )
-        
+
         response_text = pam_response.content or "I processed your message."
         logger.info(f"🤖 PAM Response: {response_text}")
-        
+
         # Step 3: Text-to-Speech (TTS) - Return both text and TTS instruction
         # For now, return JSON response since frontend handles TTS via Nari Labs
         return {
@@ -256,44 +302,53 @@ async def pam_voice(audio: UploadFile = File(...)):
             "actions": pam_response.actions,
             "confidence": pam_response.confidence,
             "voice_ready": True,
-            "pipeline": "STT→LLM→TTS"
+            "pipeline": "STT→LLM→TTS",
         }
-        
+
     except Exception as e:
         logger.error(f"❌ Voice pipeline error: {e}")
         return {
             "error": str(e),
             "text": "",
             "response": "Sorry, I had trouble processing your voice message.",
-            "pipeline": "STT→LLM→TTS"
+            "pipeline": "STT→LLM→TTS",
         }
+
 
 # Global exception handler with monitoring
 @app.exception_handler(Exception)
 async def global_exception_handler(request: Request, exc: Exception):
     """Global exception handler with comprehensive monitoring"""
     # Capture exception in Sentry with context
-    sentry_service.capture_exception(exc, {
-        "method": request.method,
-        "endpoint": request.url.path,
-        "query_params": str(request.query_params),
-        "client_host": request.client.host if request.client else "unknown"
-    })
-    
+    sentry_service.capture_exception(
+        exc,
+        {
+            "method": request.method,
+            "endpoint": request.url.path,
+            "query_params": str(request.query_params),
+            "client_host": request.client.host if request.client else "unknown",
+        },
+    )
+
     # Log security-relevant errors
     if "authentication" in str(exc).lower() or "authorization" in str(exc).lower():
-        logger.warning(f"Security-related error in {request.method} {request.url.path}: {exc}")
+        logger.warning(
+            f"Security-related error in {request.method} {request.url.path}: {exc}"
+        )
     else:
-        logger.error(f"Unhandled exception in {request.method} {request.url.path}: {exc}")
-    
+        logger.error(
+            f"Unhandled exception in {request.method} {request.url.path}: {exc}"
+        )
+
     return JSONResponse(
         status_code=500,
         content={
             "error": "Internal server error",
             "path": str(request.url.path),
-            "method": request.method
-        }
+            "method": request.method,
+        },
     )
+
 
 # ... keep existing code (security and performance status endpoints)
 
@@ -302,7 +357,7 @@ __all__ = ["app"]
 
 if __name__ == "__main__":
     import uvicorn
-    
+
     uvicorn.run(
         "app.main:app",
         host="0.0.0.0",
@@ -311,5 +366,5 @@ if __name__ == "__main__":
         workers=1 if settings.ENVIRONMENT == "development" else 4,
         loop="uvloop",
         http="httptools",
-        access_log=settings.ENVIRONMENT == "development"
+        access_log=settings.ENVIRONMENT == "development",
     )

--- a/backend/app/observability/config.py
+++ b/backend/app/observability/config.py
@@ -10,6 +10,7 @@ from openai import OpenAI
 # Optional imports - make agentops optional for deployment
 try:
     import agentops
+
     AGENTOPS_AVAILABLE = True
 except ImportError:
     AGENTOPS_AVAILABLE = False
@@ -17,6 +18,7 @@ except ImportError:
 
 try:
     from langfuse import Langfuse
+
     LANGFUSE_AVAILABLE = True
 except ImportError:
     LANGFUSE_AVAILABLE = False
@@ -28,6 +30,7 @@ try:
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import BatchSpanProcessor
     from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+
     OPENTELEMETRY_AVAILABLE = True
 except ImportError:
     OPENTELEMETRY_AVAILABLE = False
@@ -40,9 +43,10 @@ from app.core.config import get_settings
 
 logger = logging.getLogger(__name__)
 
+
 class ObservabilityConfig:
     """Centralized observability configuration using existing settings"""
-    
+
     def __init__(self):
         self.settings = get_settings()
         self.openai_client: Optional[OpenAI] = None
@@ -50,96 +54,140 @@ class ObservabilityConfig:
         self.agentops_initialized = False
         self.tracer = None
         self._initialized = False
-        
+
     def is_enabled(self) -> bool:
         """Check if observability is enabled"""
         return self.settings.OBSERVABILITY_ENABLED
-        
+
+    def initialize_tracing(self) -> None:
+        """Set up OpenTelemetry tracing if available"""
+        if not OPENTELEMETRY_AVAILABLE or self.tracer:
+            if not OPENTELEMETRY_AVAILABLE:
+                logger.info(
+                    "OpenTelemetry not available, skipping tracing initialization"
+                )
+            return
+
+        trace.set_tracer_provider(TracerProvider())
+
+        if self.settings.OTLP_ENDPOINT:
+            otlp_exporter = OTLPSpanExporter(
+                endpoint=self.settings.OTLP_ENDPOINT,
+                headers=(
+                    {"api-key": self.settings.OTLP_API_KEY}
+                    if self.settings.OTLP_API_KEY
+                    else {}
+                ),
+            )
+            span_processor = BatchSpanProcessor(otlp_exporter)
+            trace.get_tracer_provider().add_span_processor(span_processor)
+
+        self.tracer = trace.get_tracer(__name__)
+        logger.info("✅ OpenTelemetry tracing initialized")
+
     def initialize_openai(self) -> Optional[OpenAI]:
         """Initialize OpenAI client with tracing"""
         if not self.settings.OPENAI_API_KEY:
-            logger.info("OpenAI API key not configured - set OPENAI_API_KEY to enable OpenAI observability")
+            logger.info(
+                "OpenAI API key not configured - set OPENAI_API_KEY to enable OpenAI observability"
+            )
             return None
-            
+
         try:
             self.openai_client = OpenAI(api_key=self.settings.OPENAI_API_KEY)
-            
-            # Set up OpenTelemetry tracing (only if available)
-            if OPENTELEMETRY_AVAILABLE and not self.tracer:
-                trace.set_tracer_provider(TracerProvider())
-                self.tracer = trace.get_tracer(__name__)
-            elif not OPENTELEMETRY_AVAILABLE:
-                logger.info("OpenTelemetry not available, skipping trace setup")
-            
+
+            # Ensure tracing is configured
+            self.initialize_tracing()
+
             logger.info("✅ OpenAI observability initialized")
             return self.openai_client
-            
+
         except Exception as e:
             logger.warning(f"Failed to initialize OpenAI observability: {e}")
             return None
-            
-    def initialize_langfuse(self) -> Optional['Langfuse']:
+
+    def initialize_langfuse(self) -> Optional["Langfuse"]:
         """Initialize Langfuse for LLM observability"""
         if not LANGFUSE_AVAILABLE:
-            logger.info("Langfuse not available - install langfuse package to enable Langfuse observability")
+            logger.info(
+                "Langfuse not available - install langfuse package to enable Langfuse observability"
+            )
             return None
-            
-        if not (self.settings.LANGFUSE_SECRET_KEY and self.settings.LANGFUSE_PUBLIC_KEY):
-            logger.info("Langfuse credentials not configured - set LANGFUSE_SECRET_KEY and LANGFUSE_PUBLIC_KEY to enable Langfuse observability")
+
+        if not (
+            self.settings.LANGFUSE_SECRET_KEY and self.settings.LANGFUSE_PUBLIC_KEY
+        ):
+            logger.info(
+                "Langfuse credentials not configured - set LANGFUSE_SECRET_KEY and LANGFUSE_PUBLIC_KEY to enable Langfuse observability"
+            )
             return None
-            
+
         try:
             self.langfuse_client = Langfuse(
                 secret_key=self.settings.LANGFUSE_SECRET_KEY,
                 public_key=self.settings.LANGFUSE_PUBLIC_KEY,
-                host=self.settings.LANGFUSE_HOST
+                host=self.settings.LANGFUSE_HOST,
             )
-            
+
             logger.info("✅ Langfuse observability initialized")
             return self.langfuse_client
-            
+
         except Exception as e:
             logger.warning(f"Failed to initialize Langfuse observability: {e}")
             return None
-            
+
     def initialize_agentops(self) -> bool:
         """Initialize AgentOps for agent workflow tracking"""
         if not AGENTOPS_AVAILABLE:
-            logger.info("AgentOps not available - install agentops package to enable AgentOps observability")
+            logger.info(
+                "AgentOps not available - install agentops package to enable AgentOps observability"
+            )
             return False
-            
+
         if not self.settings.AGENTOPS_API_KEY:
-            logger.info("AgentOps API key not configured - set AGENTOPS_API_KEY to enable AgentOps observability")
+            logger.info(
+                "AgentOps API key not configured - set AGENTOPS_API_KEY to enable AgentOps observability"
+            )
             return False
-        
-        logger.info("🔍 Attempting AgentOps initialization with OpenAI compatibility check...")
-        
+
+        logger.info(
+            "🔍 Attempting AgentOps initialization with OpenAI compatibility check..."
+        )
+
         try:
             import openai
+
             logger.info(f"📋 OpenAI version detected: {openai.__version__}")
-            
+
             try:
                 import openai.resources.beta.chat
+
                 logger.info("✅ OpenAI module structure compatible with AgentOps")
             except ImportError:
-                logger.warning("⚠️ OpenAI module structure incompatible with current AgentOps version")
-                logger.warning("   AgentOps will be disabled to preserve core OpenAI functionality")
+                logger.warning(
+                    "⚠️ OpenAI module structure incompatible with current AgentOps version"
+                )
+                logger.warning(
+                    "   AgentOps will be disabled to preserve core OpenAI functionality"
+                )
                 self.agentops_initialized = False
                 return False
-            
+
             # AgentOps API updated - remove environment parameter
-            agentops.init(
-                api_key=self.settings.AGENTOPS_API_KEY
-            )
-            
+            agentops.init(api_key=self.settings.AGENTOPS_API_KEY)
+
             self.agentops_initialized = True
             logger.info("✅ AgentOps observability initialized successfully")
             return True
-            
+
         except ImportError as e:
             if "openai.resources.beta.chat" in str(e):
-                logger.warning("⚠️ AgentOps-OpenAI compatibility issue detected during initialization.")
-                logger.warning("   Disabling AgentOps to preserve core OpenAI functionality for PAM.")
+                logger.warning(
+                    "⚠️ AgentOps-OpenAI compatibility issue detected during initialization."
+                )
+                logger.warning(
+                    "   Disabling AgentOps to preserve core OpenAI functionality for PAM."
+                )
                 logger.warning(f"   Error details: {e}")
                 self.agentops_initialized = False
                 return False
@@ -151,31 +199,31 @@ class ObservabilityConfig:
             logger.warning(f"Failed to initialize AgentOps observability: {e}")
             self.agentops_initialized = False
             return False
-            
+
     def initialize_all(self):
         """Initialize all available observability platforms"""
         if not self.is_enabled():
             logger.info("Observability disabled via configuration")
             return
-            
+
         if self._initialized:
             return
-            
+
         logger.info("🚀 Initializing AI agent observability stack...")
-        
+        self.initialize_tracing()
         self.initialize_openai()
         self.initialize_langfuse()
         self.initialize_agentops()
-        
+
         self._initialized = True
         logger.info("✅ AI agent observability initialization complete")
-        
+
     def get_tracer(self):
         """Get OpenTelemetry tracer"""
         if not self.tracer:
             self.tracer = trace.get_tracer(__name__)
         return self.tracer
-        
+
     def get_status(self) -> dict:
         """Get current observability status"""
         return {
@@ -183,36 +231,42 @@ class ObservabilityConfig:
             "initialized": self._initialized,
             "openai": {
                 "configured": bool(self.settings.OPENAI_API_KEY),
-                "client_ready": self.openai_client is not None
+                "client_ready": self.openai_client is not None,
             },
             "langfuse": {
-                "configured": bool(self.settings.LANGFUSE_SECRET_KEY and self.settings.LANGFUSE_PUBLIC_KEY),
-                "client_ready": self.langfuse_client is not None
+                "configured": bool(
+                    self.settings.LANGFUSE_SECRET_KEY
+                    and self.settings.LANGFUSE_PUBLIC_KEY
+                ),
+                "client_ready": self.langfuse_client is not None,
             },
             "agentops": {
                 "configured": bool(self.settings.AGENTOPS_API_KEY),
-                "initialized": self.agentops_initialized
-            }
+                "initialized": self.agentops_initialized,
+            },
         }
-        
+
     def shutdown(self):
         """Clean shutdown of all observability platforms"""
         try:
             if self.langfuse_client:
                 self.langfuse_client.flush()
                 logger.info("✅ Langfuse client flushed")
-                
+
             if self.agentops_initialized and AGENTOPS_AVAILABLE:
                 try:
-                    agentops.end_session('Success')
+                    agentops.end_session("Success")
                     logger.info("✅ AgentOps session ended")
                 except Exception as agentops_error:
-                    logger.warning(f"⚠️ AgentOps shutdown error (non-critical): {agentops_error}")
-                
+                    logger.warning(
+                        f"⚠️ AgentOps shutdown error (non-critical): {agentops_error}"
+                    )
+
             logger.info("🔄 Observability platforms shut down cleanly")
-            
+
         except Exception as e:
             logger.error(f"❌ Error during observability shutdown: {e}")
+
 
 # Global observability instance
 observability = ObservabilityConfig()

--- a/backend/docs/MONITORING.md
+++ b/backend/docs/MONITORING.md
@@ -266,6 +266,16 @@ htop
 - Use appropriate refresh intervals
 - Optimize query expressions
 
+### Distributed Tracing
+The backend uses **OpenTelemetry** for distributed tracing. Set the following environment variables to export spans to your tracing backend:
+
+```bash
+OTLP_ENDPOINT=https://your-otel-collector.example.com
+OTLP_API_KEY=<optional-api-key>
+```
+
+Tracing is automatically enabled when these variables are present and `OBSERVABILITY_ENABLED` is `true`.
+
 ## Contact Information
 
 For monitoring-related issues:


### PR DESCRIPTION
## Summary
- expose OTLP endpoint options in backend settings
- hook OpenTelemetry into backend with FastAPI instrumentation
- initialize tracing when observability starts
- document how to enable distributed tracing

## Testing
- `npm test --silent`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'websockets')*

------
https://chatgpt.com/codex/tasks/task_e_6879f36d96e48323ba74bcbaa54ab1d9