### PR TITLE
Add configuration management utility

### DIFF
--- a/config/config_manager.py
+++ b/config/config_manager.py
@@ -1,0 +1,40 @@
+"""Simple configuration management utility."""
+import json
+import argparse
+from pathlib import Path
+
+CONFIG_DIR = Path(__file__).resolve().parent / "environments"
+ENV_FILE = Path(__file__).resolve().parent.parent / ".env"
+
+
+def apply_environment(env_name: str) -> None:
+    """Write the selected environment configuration to the project .env."""
+    env_path = CONFIG_DIR / f"{env_name}.json"
+    if not env_path.exists():
+        raise SystemExit(f"Unknown environment: {env_name}")
+    data = json.loads(env_path.read_text())
+    lines = [f"{k}={v}" for k, v in data.items()]
+    ENV_FILE.write_text("\n".join(lines) + "\n")
+    print(f"Applied configuration: {env_name}")
+
+
+def show_environments() -> None:
+    envs = [p.stem for p in CONFIG_DIR.glob("*.json")]
+    print("Available environments:", ", ".join(sorted(envs)))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Manage project configuration")
+    sub = parser.add_subparsers(dest="command")
+
+    apply_p = sub.add_parser("apply", help="Apply an environment configuration")
+    apply_p.add_argument("env")
+
+    sub.add_parser("list", help="List available environments")
+
+    args = parser.parse_args()
+
+    if args.command == "apply":
+        apply_environment(args.env)
+    else:
+        show_environments()

--- a/config/environments/development.json
+++ b/config/environments/development.json
@@ -1,0 +1,8 @@
+{
+  "VITE_BACKEND_URL": "https://pam-backend.onrender.com",
+  "VITE_PAM_WEBSOCKET_URL": "wss://pam-backend.onrender.com/api/v1/pam/ws",
+  "SUPABASE_URL": "https://your-project.supabase.co",
+  "SUPABASE_ANON_KEY": "your_supabase_anon_key",
+  "SUPABASE_SERVICE_ROLE_KEY": "your_supabase_service_role_key",
+  "VITE_MAPBOX_TOKEN": "pk.your_mapbox_token_here"
+}

--- a/config/environments/production.json
+++ b/config/environments/production.json
@@ -1,0 +1,15 @@
+{
+  "SUPABASE_URL": "",
+  "SUPABASE_ANON_KEY": "",
+  "SUPABASE_SERVICE_ROLE_KEY": "",
+  "OPENAI_API_KEY": "",
+  "REDIS_URL": "",
+  "SENTRY_DSN": "",
+  "ENVIRONMENT": "production",
+  "DEBUG": "False",
+  "SECRET_KEY": "",
+  "ALLOWED_ORIGINS": "[\"https://yourdomain.com\", \"https://www.yourdomain.com\"]",
+  "VITE_BACKEND_URL": "https://pam-backend.onrender.com",
+  "VITE_PAM_WEBSOCKET_URL": "wss://pam-backend.onrender.com/api/v1/pam/ws",
+  "VITE_MAPBOX_TOKEN": ""
+}


### PR DESCRIPTION
## Summary
- add JSON configs for development and production
- provide `config_manager.py` CLI to apply configs

## Testing
- `pip install -r backend/requirements-dev.txt` *(fails: cannot install numpy)*
- `pytest -q` *(fails: ModuleNotFoundError)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a0b059a788323ab58d0dcfff15687