### PR TITLE
Add new CRUD services and API routes

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -1,5 +1,39 @@
-from . import auth, chat, health, monitoring, pam, social, wheels, wins, subscription, voice, admin, observability
+from . import (
+    auth,
+    chat,
+    health,
+    monitoring,
+    pam,
+    social,
+    wheels,
+    wins,
+    subscription,
+    voice,
+    admin,
+    observability,
+    profiles,
+    products,
+    orders,
+    maintenance,
+    custom_routes,
+)
 
 __all__ = [
-    'auth', 'chat', 'health', 'monitoring', 'pam', 'social', 'wheels', 'wins', 'subscription', 'voice', 'admin', 'observability'
+    'auth',
+    'chat',
+    'health',
+    'monitoring',
+    'pam',
+    'social',
+    'wheels',
+    'wins',
+    'subscription',
+    'voice',
+    'admin',
+    'observability',
+    'profiles',
+    'products',
+    'orders',
+    'maintenance',
+    'custom_routes',
 ]

--- a/backend/app/api/v1/custom_routes.py
+++ b/backend/app/api/v1/custom_routes.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter, HTTPException
+from typing import Dict, Any
+from app.services.custom_routes_service import custom_routes_service
+
+router = APIRouter()
+
+@router.get("/routes/{user_id}")
+async def list_routes(user_id: str):
+    return await custom_routes_service.list_routes(user_id)
+
+@router.get("/route/{route_id}")
+async def get_route(route_id: str):
+    route = await custom_routes_service.get_route(route_id)
+    if not route:
+        raise HTTPException(status_code=404, detail="Route not found")
+    return route
+
+@router.post("/routes", status_code=201)
+async def create_route(payload: Dict[str, Any]):
+    return await custom_routes_service.create_route(payload)
+
+@router.put("/route/{route_id}")
+async def update_route(route_id: str, payload: Dict[str, Any]):
+    route = await custom_routes_service.update_route(route_id, payload)
+    if not route:
+        raise HTTPException(status_code=404, detail="Route not found")
+    return route
+
+@router.delete("/route/{route_id}")
+async def delete_route(route_id: str):
+    success = await custom_routes_service.delete_route(route_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Route not found")
+    return {"success": True}

--- a/backend/app/api/v1/maintenance.py
+++ b/backend/app/api/v1/maintenance.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter, HTTPException
+from typing import Dict, Any
+from app.services.maintenance_service import maintenance_service
+
+router = APIRouter()
+
+@router.get("/maintenance/{user_id}")
+async def list_records(user_id: str):
+    return await maintenance_service.list_records(user_id)
+
+@router.get("/maintenance/record/{record_id}")
+async def get_record(record_id: str):
+    record = await maintenance_service.get_record(record_id)
+    if not record:
+        raise HTTPException(status_code=404, detail="Record not found")
+    return record
+
+@router.post("/maintenance", status_code=201)
+async def create_record(payload: Dict[str, Any]):
+    return await maintenance_service.create_record(payload)
+
+@router.put("/maintenance/{record_id}")
+async def update_record(record_id: str, payload: Dict[str, Any]):
+    record = await maintenance_service.update_record(record_id, payload)
+    if not record:
+        raise HTTPException(status_code=404, detail="Record not found")
+    return record
+
+@router.delete("/maintenance/{record_id}")
+async def delete_record(record_id: str):
+    success = await maintenance_service.delete_record(record_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Record not found")
+    return {"success": True}

--- a/backend/app/api/v1/orders.py
+++ b/backend/app/api/v1/orders.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter, HTTPException
+from typing import Dict, Any
+from app.services.orders_service import orders_service
+
+router = APIRouter()
+
+@router.get("/orders")
+async def list_orders():
+    return await orders_service.list_orders()
+
+@router.get("/orders/{order_id}")
+async def get_order(order_id: str):
+    order = await orders_service.get_order(order_id)
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+    return order
+
+@router.post("/orders", status_code=201)
+async def create_order(payload: Dict[str, Any]):
+    return await orders_service.create_order(payload)
+
+@router.put("/orders/{order_id}")
+async def update_order(order_id: str, payload: Dict[str, Any]):
+    order = await orders_service.update_order(order_id, payload)
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+    return order
+
+@router.delete("/orders/{order_id}")
+async def delete_order(order_id: str):
+    success = await orders_service.delete_order(order_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Order not found")
+    return {"success": True}

--- a/backend/app/api/v1/products.py
+++ b/backend/app/api/v1/products.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter, HTTPException
+from typing import Dict, Any
+from app.services.products_service import products_service
+
+router = APIRouter()
+
+@router.get("/products")
+async def list_products():
+    return await products_service.list_products()
+
+@router.get("/products/{product_id}")
+async def get_product(product_id: str):
+    product = await products_service.get_product(product_id)
+    if not product:
+        raise HTTPException(status_code=404, detail="Product not found")
+    return product
+
+@router.post("/products", status_code=201)
+async def create_product(payload: Dict[str, Any]):
+    return await products_service.create_product(payload)
+
+@router.put("/products/{product_id}")
+async def update_product(product_id: str, payload: Dict[str, Any]):
+    product = await products_service.update_product(product_id, payload)
+    if not product:
+        raise HTTPException(status_code=404, detail="Product not found")
+    return product
+
+@router.delete("/products/{product_id}")
+async def delete_product(product_id: str):
+    success = await products_service.delete_product(product_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Product not found")
+    return {"success": True}

--- a/backend/app/api/v1/profiles.py
+++ b/backend/app/api/v1/profiles.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter, HTTPException
+from typing import Dict, Any
+from app.services.profiles_service import profiles_service
+
+router = APIRouter()
+
+@router.get("/profiles/{profile_id}")
+async def get_profile(profile_id: str):
+    profile = await profiles_service.get_profile(profile_id)
+    if not profile:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    return profile
+
+@router.post("/profiles", status_code=201)
+async def create_profile(payload: Dict[str, Any]):
+    return await profiles_service.create_profile(payload)
+
+@router.put("/profiles/{profile_id}")
+async def update_profile(profile_id: str, payload: Dict[str, Any]):
+    profile = await profiles_service.update_profile(profile_id, payload)
+    if not profile:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    return profile
+
+@router.delete("/profiles/{profile_id}")
+async def delete_profile(profile_id: str):
+    success = await profiles_service.delete_profile(profile_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    return {"success": True}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -51,6 +51,11 @@ from app.api.v1 import (
     tts,
     search,
     vision,
+    profiles,
+    products,
+    orders,
+    maintenance,
+    custom_routes,
 )
 from app.api import websocket, actions
 from app.api.v1 import voice_streaming
@@ -233,6 +238,11 @@ app.include_router(wins.router, prefix="/api", tags=["Wins"])
 app.include_router(wheels.router, prefix="/api", tags=["Wheels"])
 app.include_router(social.router, prefix="/api", tags=["Social"])
 app.include_router(pam.router, prefix="/api/v1/pam", tags=["PAM"])
+app.include_router(profiles.router, prefix="/api/v1", tags=["Profiles"])
+app.include_router(products.router, prefix="/api/v1", tags=["Products"])
+app.include_router(orders.router, prefix="/api/v1", tags=["Orders"])
+app.include_router(maintenance.router, prefix="/api/v1", tags=["Maintenance"])
+app.include_router(custom_routes.router, prefix="/api/v1", tags=["Routes"])
 # Removed generic websocket router to avoid conflicts with PAM WebSocket
 # app.include_router(websocket.router, prefix="/api", tags=["WebSocket"])
 app.include_router(auth.router, prefix="/api/auth", tags=["Authentication"])

--- a/backend/app/services/custom_routes_service.py
+++ b/backend/app/services/custom_routes_service.py
@@ -1,0 +1,44 @@
+from typing import Any, Dict, Optional
+from app.database.supabase_client import get_supabase_client
+
+class CustomRoutesService:
+    def __init__(self):
+        self.client = get_supabase_client()
+
+    async def create_route(self, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        result = self.client.table("custom_routes").insert(data).execute()
+        return result.data[0] if result.data else None
+
+    async def get_route(self, route_id: str) -> Optional[Dict[str, Any]]:
+        result = (
+            self.client.table("custom_routes")
+            .select("*")
+            .eq("id", route_id)
+            .single()
+            .execute()
+        )
+        return result.data if result.data else None
+
+    async def update_route(self, route_id: str, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        result = (
+            self.client.table("custom_routes")
+            .update(data)
+            .eq("id", route_id)
+            .execute()
+        )
+        return result.data[0] if result.data else None
+
+    async def delete_route(self, route_id: str) -> bool:
+        result = self.client.table("custom_routes").delete().eq("id", route_id).execute()
+        return bool(result.data)
+
+    async def list_routes(self, user_id: str) -> list[Dict[str, Any]]:
+        result = (
+            self.client.table("custom_routes")
+            .select("*")
+            .eq("user_id", user_id)
+            .execute()
+        )
+        return result.data or []
+
+custom_routes_service = CustomRoutesService()

--- a/backend/app/services/maintenance_service.py
+++ b/backend/app/services/maintenance_service.py
@@ -1,0 +1,44 @@
+from typing import Any, Dict, Optional
+from app.database.supabase_client import get_supabase_client
+
+class MaintenanceService:
+    def __init__(self):
+        self.client = get_supabase_client()
+
+    async def create_record(self, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        result = self.client.table("maintenance_records").insert(data).execute()
+        return result.data[0] if result.data else None
+
+    async def get_record(self, record_id: str) -> Optional[Dict[str, Any]]:
+        result = (
+            self.client.table("maintenance_records")
+            .select("*")
+            .eq("id", record_id)
+            .single()
+            .execute()
+        )
+        return result.data if result.data else None
+
+    async def update_record(self, record_id: str, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        result = (
+            self.client.table("maintenance_records")
+            .update(data)
+            .eq("id", record_id)
+            .execute()
+        )
+        return result.data[0] if result.data else None
+
+    async def delete_record(self, record_id: str) -> bool:
+        result = self.client.table("maintenance_records").delete().eq("id", record_id).execute()
+        return bool(result.data)
+
+    async def list_records(self, user_id: str) -> list[Dict[str, Any]]:
+        result = (
+            self.client.table("maintenance_records")
+            .select("*")
+            .eq("user_id", user_id)
+            .execute()
+        )
+        return result.data or []
+
+maintenance_service = MaintenanceService()

--- a/backend/app/services/orders_service.py
+++ b/backend/app/services/orders_service.py
@@ -1,0 +1,39 @@
+from typing import Any, Dict, Optional
+from app.database.supabase_client import get_supabase_client
+
+class OrdersService:
+    def __init__(self):
+        self.client = get_supabase_client()
+
+    async def create_order(self, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        result = self.client.table("shop_orders").insert(data).execute()
+        return result.data[0] if result.data else None
+
+    async def get_order(self, order_id: str) -> Optional[Dict[str, Any]]:
+        result = (
+            self.client.table("shop_orders")
+            .select("*")
+            .eq("id", order_id)
+            .single()
+            .execute()
+        )
+        return result.data if result.data else None
+
+    async def update_order(self, order_id: str, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        result = (
+            self.client.table("shop_orders")
+            .update(data)
+            .eq("id", order_id)
+            .execute()
+        )
+        return result.data[0] if result.data else None
+
+    async def delete_order(self, order_id: str) -> bool:
+        result = self.client.table("shop_orders").delete().eq("id", order_id).execute()
+        return bool(result.data)
+
+    async def list_orders(self) -> list[Dict[str, Any]]:
+        result = self.client.table("shop_orders").select("*").execute()
+        return result.data or []
+
+orders_service = OrdersService()

--- a/backend/app/services/products_service.py
+++ b/backend/app/services/products_service.py
@@ -1,0 +1,39 @@
+from typing import Any, Dict, Optional
+from app.database.supabase_client import get_supabase_client
+
+class ProductsService:
+    def __init__(self):
+        self.client = get_supabase_client()
+
+    async def create_product(self, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        result = self.client.table("shop_products").insert(data).execute()
+        return result.data[0] if result.data else None
+
+    async def get_product(self, product_id: str) -> Optional[Dict[str, Any]]:
+        result = (
+            self.client.table("shop_products")
+            .select("*")
+            .eq("id", product_id)
+            .single()
+            .execute()
+        )
+        return result.data if result.data else None
+
+    async def update_product(self, product_id: str, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        result = (
+            self.client.table("shop_products")
+            .update(data)
+            .eq("id", product_id)
+            .execute()
+        )
+        return result.data[0] if result.data else None
+
+    async def delete_product(self, product_id: str) -> bool:
+        result = self.client.table("shop_products").delete().eq("id", product_id).execute()
+        return bool(result.data)
+
+    async def list_products(self) -> list[Dict[str, Any]]:
+        result = self.client.table("shop_products").select("*").execute()
+        return result.data or []
+
+products_service = ProductsService()

--- a/backend/app/services/profiles_service.py
+++ b/backend/app/services/profiles_service.py
@@ -1,0 +1,35 @@
+from typing import Any, Dict, Optional
+from app.database.supabase_client import get_supabase_client
+
+class ProfilesService:
+    def __init__(self):
+        self.client = get_supabase_client()
+
+    async def create_profile(self, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        result = self.client.table("profiles").insert(data).execute()
+        return result.data[0] if result.data else None
+
+    async def get_profile(self, profile_id: str) -> Optional[Dict[str, Any]]:
+        result = (
+            self.client.table("profiles")
+            .select("*")
+            .eq("id", profile_id)
+            .single()
+            .execute()
+        )
+        return result.data if result.data else None
+
+    async def update_profile(self, profile_id: str, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        result = (
+            self.client.table("profiles")
+            .update(data)
+            .eq("id", profile_id)
+            .execute()
+        )
+        return result.data[0] if result.data else None
+
+    async def delete_profile(self, profile_id: str) -> bool:
+        result = self.client.table("profiles").delete().eq("id", profile_id).execute()
+        return bool(result.data)
+
+profiles_service = ProfilesService()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -180,6 +180,41 @@ def sample_maintenance_data():
 
 
 @pytest.fixture
+def sample_product_data():
+    """Sample product data for tests."""
+    return {
+        "id": 1,
+        "name": "Test Product",
+        "price": 9.99,
+        "status": "active",
+    }
+
+
+@pytest.fixture
+def sample_order_data(sample_user_data):
+    """Sample order data for tests."""
+    return {
+        "id": 1,
+        "user_id": sample_user_data["id"],
+        "product_id": 1,
+        "quantity": 2,
+        "status": "pending",
+    }
+
+
+@pytest.fixture
+def sample_custom_route_data(sample_user_data):
+    """Sample custom route data for tests."""
+    return {
+        "id": 1,
+        "user_id": sample_user_data["id"],
+        "name": "Scenic Route",
+        "origin": "A",
+        "destination": "B",
+    }
+
+
+@pytest.fixture
 def sample_chat_data():
     """Sample chat conversation data for tests."""
     return {

--- a/backend/tests/unit/test_crud_services.py
+++ b/backend/tests/unit/test_crud_services.py
@@ -1,0 +1,82 @@
+import pytest
+from app.services.profiles_service import ProfilesService
+from app.services.products_service import ProductsService
+from app.services.orders_service import OrdersService
+from app.services.maintenance_service import MaintenanceService
+from app.services.custom_routes_service import CustomRoutesService
+
+
+@pytest.fixture
+def profiles_service(mock_supabase_client):
+    service = ProfilesService()
+    service.client = mock_supabase_client
+    return service
+
+
+@pytest.fixture
+def products_service(mock_supabase_client):
+    service = ProductsService()
+    service.client = mock_supabase_client
+    return service
+
+
+@pytest.fixture
+def orders_service(mock_supabase_client):
+    service = OrdersService()
+    service.client = mock_supabase_client
+    return service
+
+
+@pytest.fixture
+def maintenance_service_fixture(mock_supabase_client):
+    service = MaintenanceService()
+    service.client = mock_supabase_client
+    return service
+
+
+@pytest.fixture
+def custom_routes_service_fixture(mock_supabase_client):
+    service = CustomRoutesService()
+    service.client = mock_supabase_client
+    return service
+
+
+@pytest.mark.asyncio
+async def test_create_profile(profiles_service, sample_user_data):
+    profiles_service.client.table().insert().execute.return_value.data = [sample_user_data]
+    result = await profiles_service.create_profile(sample_user_data)
+    assert result == sample_user_data
+    profiles_service.client.table.assert_called_with("profiles")
+
+
+@pytest.mark.asyncio
+async def test_update_product(products_service, sample_product_data):
+    updated = {**sample_product_data, "price": 19.99}
+    products_service.client.table().update().eq().execute.return_value.data = [updated]
+    result = await products_service.update_product(sample_product_data["id"], {"price": 19.99})
+    assert result == updated
+    products_service.client.table.assert_called_with("shop_products")
+
+
+@pytest.mark.asyncio
+async def test_get_order(orders_service, sample_order_data):
+    orders_service.client.table().select().eq().single().execute.return_value.data = sample_order_data
+    result = await orders_service.get_order(sample_order_data["id"])
+    assert result == sample_order_data
+    orders_service.client.table.assert_called_with("shop_orders")
+
+
+@pytest.mark.asyncio
+async def test_delete_maintenance_record(maintenance_service_fixture):
+    maintenance_service_fixture.client.table().delete().eq().execute.return_value.data = [True]
+    success = await maintenance_service_fixture.delete_record(1)
+    assert success
+    maintenance_service_fixture.client.table.assert_called_with("maintenance_records")
+
+
+@pytest.mark.asyncio
+async def test_list_custom_routes(custom_routes_service_fixture, sample_custom_route_data):
+    custom_routes_service_fixture.client.table().select().eq().execute.return_value.data = [sample_custom_route_data]
+    result = await custom_routes_service_fixture.list_routes(sample_custom_route_data["user_id"])
+    assert result == [sample_custom_route_data]
+    custom_routes_service_fixture.client.table.assert_called_with("custom_routes")

--- a/docs/technical/api-documentation.md
+++ b/docs/technical/api-documentation.md
@@ -515,6 +515,42 @@ Update vehicle information.
 ### DELETE /vehicles/{vehicle_id}
 Remove a vehicle.
 
+## Data Management Endpoints
+
+### Profiles
+- `GET /api/v1/profiles/{id}` - Retrieve a profile
+- `POST /api/v1/profiles` - Create a new profile
+- `PUT /api/v1/profiles/{id}` - Update a profile
+- `DELETE /api/v1/profiles/{id}` - Delete a profile
+
+### Products
+- `GET /api/v1/products` - List products
+- `GET /api/v1/products/{id}` - Retrieve a product
+- `POST /api/v1/products` - Create a product
+- `PUT /api/v1/products/{id}` - Update a product
+- `DELETE /api/v1/products/{id}` - Delete a product
+
+### Orders
+- `GET /api/v1/orders` - List orders
+- `GET /api/v1/orders/{id}` - Retrieve an order
+- `POST /api/v1/orders` - Create an order
+- `PUT /api/v1/orders/{id}` - Update an order
+- `DELETE /api/v1/orders/{id}` - Delete an order
+
+### Maintenance Records
+- `GET /api/v1/maintenance/{user_id}` - List maintenance records
+- `GET /api/v1/maintenance/record/{id}` - Retrieve a maintenance record
+- `POST /api/v1/maintenance` - Create a record
+- `PUT /api/v1/maintenance/{id}` - Update a record
+- `DELETE /api/v1/maintenance/{id}` - Delete a record
+
+### Custom Routes
+- `GET /api/v1/routes/{user_id}` - List saved routes
+- `GET /api/v1/route/{id}` - Retrieve a route
+- `POST /api/v1/routes` - Create a route
+- `PUT /api/v1/route/{id}` - Update a route
+- `DELETE /api/v1/route/{id}` - Delete a route
+
 ## Error Responses
 
 All endpoints may return the following error responses:


### PR DESCRIPTION
## Summary
- add service modules for profiles, products, orders, maintenance, and custom routes
- expose CRUD API endpoints under `/api/v1`
- wire routers into main application
- extend docs with data management endpoint summary
- test CRUD services

## Testing
- `pytest -c backend/pytest.ini backend/tests/unit/test_crud_services.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687a12c93500832392f4beb21d7418ef