### PR TITLE
Add core pipeline unit tests

### DIFF
--- a/tests/data/expected_trip.json
+++ b/tests/data/expected_trip.json
@@ -1,0 +1,11 @@
+{
+  "start_location": "Los Angeles",
+  "end_location": "San Francisco",
+  "waypoints": ["Santa Barbara", "Monterey"],
+  "duration_days": 5,
+  "highlights": [],
+  "costs": "$500",
+  "campgrounds": [],
+  "route_description": null,
+  "confidence": 1.0
+}

--- a/tests/data/sample_transcript.txt
+++ b/tests/data/sample_transcript.txt
@@ -1,0 +1,1 @@
+We drove from Los Angeles to San Francisco stopping at Santa Barbara and Monterey. The trip lasted 5 days and cost around $500.

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+import os
+import pytest
+
+# Ensure src package is importable
+repo_root = Path(__file__).resolve().parent.parent
+src_path = repo_root / "src"
+for p in (repo_root, src_path):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+
+
+def test_settings_load(monkeypatch):
+    monkeypatch.setenv("YOUTUBE_API_KEY", "k")
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setenv("SUPABASE_URL", "http://x")
+    monkeypatch.setenv("SUPABASE_ANON_KEY", "a")
+    import importlib
+    Settings = importlib.import_module("config.settings").Settings
+    cfg = Settings.load()
+    assert cfg.youtube.API_KEY == "k"

--- a/tests/test_database_operations.py
+++ b/tests/test_database_operations.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+# Ensure src package is importable
+repo_root = Path(__file__).resolve().parent.parent
+src_path = repo_root / "src"
+for p in (repo_root, src_path):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+from src.database import SupabaseClient
+
+
+def sample_trip():
+    return {
+        "name": "Test Trip",
+        "start_location": "A",
+        "end_location": "B",
+        "duration_days": 3,
+    }
+
+
+@patch("src.database.create_client", side_effect=Exception("no supabase"))
+def test_crud_operations(mock_create):
+    client = SupabaseClient("u", "k")
+    trip = client.create_trip(sample_trip())
+    fetched = client.read_trip(trip.id)
+    assert fetched == trip
+    updated = client.update_trip(trip.id, name="New")
+    assert updated.name == "New"
+    assert client.delete_trip(trip.id)

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Ensure src package is importable
+repo_root = Path(__file__).resolve().parent.parent
+src_path = repo_root / "src"
+for p in (repo_root, src_path):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+from src.youtube_client import YouTubeAPIClient, YouTubeAPIError
+from src.trip_extractor import TripExtractor
+
+
+@patch("src.youtube_client.build")
+def test_search_error(mock_build):
+    class DummyRequest:
+        def execute(self):
+            raise Exception("fail")
+    dummy = MagicMock()
+    dummy.search.return_value.list.return_value = DummyRequest()
+    mock_build.return_value = dummy
+    client = YouTubeAPIClient("k")
+    with pytest.raises(YouTubeAPIError):
+        client.search_videos("q")
+
+
+@pytest.mark.asyncio
+async def test_openai_error(monkeypatch):
+    async_client = MagicMock()
+    async_client.chat.completions.create = AsyncMock(side_effect=Exception("fail"))
+    with patch("src.trip_extractor.AsyncOpenAI", return_value=async_client):
+        extractor = TripExtractor()
+        trip = await extractor.extract("from X to Y")
+    assert trip.start_location == "X"
+    assert trip.end_location == "Y"

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+import time
+import pytest
+from unittest.mock import patch
+
+# Ensure src package is importable
+repo_root = Path(__file__).resolve().parent.parent
+src_path = repo_root / "src"
+for p in (repo_root, src_path):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+from src.main import process_batch
+from src.trip_extractor import TripData
+
+
+class DummyYT:
+    def get_transcript(self, video_id):
+        return "t"
+
+
+class DummyExtractor:
+    async def extract(self, transcript):
+        return TripData(start_location="A", end_location="B", confidence=1.0)
+
+
+@pytest.mark.asyncio
+async def test_batch_performance():
+    videos = [f"v{i}" for i in range(50)]
+    with patch("src.main.YouTubeAPIClient", return_value=DummyYT()), \
+         patch("src.main.TripExtractor", return_value=DummyExtractor()):
+        start = time.perf_counter()
+        await process_batch("k", videos, resume=False)
+        duration = time.perf_counter() - start
+    assert duration < 1.0

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -1,0 +1,40 @@
+import asyncio
+import sys
+from pathlib import Path
+import pytest
+from unittest.mock import AsyncMock, patch
+
+# Ensure src package is importable
+repo_root = Path(__file__).resolve().parent.parent
+src_path = repo_root / "src"
+for p in (repo_root, src_path):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+from src.main import process_batch
+from src.trip_extractor import TripData
+
+
+class DummyYT:
+    def __init__(self, transcript="hi"):
+        self.transcript = transcript
+
+    def get_transcript(self, video_id):
+        return self.transcript
+
+
+class DummyExtractor:
+    async def extract(self, transcript):
+        return TripData(start_location="A", end_location="B", confidence=1.0)
+
+
+@pytest.mark.asyncio
+async def test_process_batch(monkeypatch):
+    videos = ["v1", "v2", "v3"]
+    with patch("src.main.YouTubeAPIClient", return_value=DummyYT()), \
+         patch("src.main.TripExtractor", return_value=DummyExtractor()):
+        report = await process_batch("k", videos, resume=False)
+    assert report["total"] == 3
+    assert report["success"] == 3
+    assert report["failure"] == 0
+    assert report["success_rate"] == 1.0

--- a/tests/test_trip_extractor_unit.py
+++ b/tests/test_trip_extractor_unit.py
@@ -1,0 +1,61 @@
+import sys
+from pathlib import Path
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Ensure src package is importable
+repo_root = Path(__file__).resolve().parent.parent
+src_path = repo_root / "src"
+for p in (repo_root, src_path):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+from src.trip_extractor import TripExtractor, TripData
+
+
+class DummyChoice:
+    def __init__(self, content):
+        self.message = MagicMock(content=content)
+
+
+class DummyResponse:
+    def __init__(self, content):
+        self.choices = [DummyChoice(content)]
+
+
+@pytest.mark.asyncio
+async def test_extract_valid(monkeypatch):
+    data_path = Path(__file__).with_name("data") / "expected_trip.json"
+    expected = json.loads(data_path.read_text())
+    async_client = MagicMock()
+    async_client.chat.completions.create = AsyncMock(return_value=DummyResponse(json.dumps(expected)))
+    with patch("src.trip_extractor.AsyncOpenAI", return_value=async_client):
+        extractor = TripExtractor()
+        transcript = (Path(__file__).with_name("data") / "sample_transcript.txt").read_text()
+        trip = await extractor.extract(transcript)
+    assert trip.start_location == expected["start_location"]
+    assert trip.end_location == expected["end_location"]
+
+
+@pytest.mark.asyncio
+async def test_extract_fallback(monkeypatch):
+    async_client = MagicMock()
+    async_client.chat.completions.create = AsyncMock(side_effect=Exception("fail"))
+    with patch("src.trip_extractor.AsyncOpenAI", return_value=async_client):
+        extractor = TripExtractor()
+        trip = await extractor.extract("from A to B stopping at C")
+    assert trip.start_location == "A"
+    assert "B" in trip.end_location
+    assert "C" in trip.waypoints
+
+
+@pytest.mark.asyncio
+async def test_batch_extract(monkeypatch):
+    async_client = MagicMock()
+    async_client.chat.completions.create = AsyncMock(return_value=DummyResponse('{"start_location":"A","end_location":"B"}'))
+    with patch("src.trip_extractor.AsyncOpenAI", return_value=async_client):
+        extractor = TripExtractor()
+        trips = await extractor.batch_extract(["t1", "t2"])
+    assert len(trips) == 2
+    assert all(isinstance(t, TripData) for t in trips)

--- a/tests/test_youtube_client_unit.py
+++ b/tests/test_youtube_client_unit.py
@@ -1,0 +1,78 @@
+import sys
+from pathlib import Path
+import pytest
+from unittest.mock import MagicMock, patch
+
+# Ensure src package is importable
+repo_root = Path(__file__).resolve().parent.parent
+src_path = repo_root / "src"
+for p in (repo_root, src_path):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+from src.youtube_client import YouTubeAPIClient, SearchFilters, YouTubeAPIError
+
+
+class DummyService:
+    def __init__(self, responses):
+        self.responses = responses
+
+    def search(self):
+        return self
+
+    def videos(self):
+        return self
+
+    def captions(self):
+        return self
+
+    def list(self, **kwargs):
+        key = kwargs.get("id") or kwargs.get("videoId") or "search"
+        return MagicMock(execute=lambda: self.responses[key])
+
+    def download(self, id):
+        return MagicMock(execute=lambda: b"caption text")
+
+
+@patch("src.youtube_client.build")
+def test_search_videos_basic(mock_build):
+    service = DummyService({
+        "search": {"items": [{"id": {"videoId": "abc"}}]},
+        "abc": {"items": [{
+            "id": "abc",
+            "snippet": {"title": "t", "description": "d", "channelTitle": "c", "publishedAt": "2020"},
+            "statistics": {"viewCount": "10"}
+        }]}
+    })
+    mock_build.return_value = service
+    client = YouTubeAPIClient("k")
+    videos = client.search_videos("q", max_results=1)
+    assert videos[0]["id"] == "abc"
+    assert videos[0]["viewCount"] == 10
+
+
+@patch("src.youtube_client.build")
+def test_get_transcript_caption(mock_build):
+    service = DummyService({
+        "search": {},
+        "abc": {"items": [{"id": "abc"}]},
+        "captions": {"items": [{"id": "cap"}]},
+    })
+    def list_side(**kwargs):
+        if "part" in kwargs and kwargs["part"] == "id":
+            return MagicMock(execute=lambda: service.responses["captions"])
+        return MagicMock(execute=lambda: service.responses["abc"])
+    service.captions = lambda: service
+    service.list = list_side
+    mock_build.return_value = service
+
+    client = YouTubeAPIClient("k")
+    result = client.get_transcript("abc")
+    assert result == "caption text"
+
+
+@patch("src.youtube_client.build", side_effect=Exception("fail"))
+def test_client_import_error(mock_build):
+    with pytest.raises(Exception):
+        YouTubeAPIClient("k")
+


### PR DESCRIPTION
## Summary
- convert `src` to a package so Python tests can import it
- add sample transcript and expected result fixtures
- create unit tests for YouTube client and trip extractor
- add integration and performance tests for processing pipeline
- add simple configuration and database tests
- include error-handling checks

## Testing
- `pytest tests/test_youtube_client_unit.py tests/test_trip_extractor_unit.py tests/test_pipeline_integration.py tests/test_config_validation.py tests/test_database_operations.py tests/test_performance.py tests/test_error_handling.py -q`
- `pytest tests -q` *(fails: ModuleNotFoundError: No module named 'redis')*

------
https://chatgpt.com/codex/tasks/task_e_687b29a5babc832380b934579721cc7c