### PR TITLE
Add detailed docs and example scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,27 @@
 
 **URL**: <YOUR_PROJECT_URL>
 
+## Setup & Usage
+
+Clone the repository and install dependencies:
+
+```bash
+git clone <YOUR_GIT_URL>
+cd wheels-wins-landing-page
+npm install
+python -m venv venv && source venv/bin/activate
+pip install -r backend/requirements.txt
+```
+
+Start the development servers:
+
+```bash
+npm run dev        # Frontend
+uvicorn app.main:app --reload --app-dir backend
+```
+
+API endpoints and authentication details are documented in [API Documentation](docs/technical/api-documentation.md).
+
 ## 🛡️ Code Quality & Security
 
 This project implements comprehensive code quality and security measures:
@@ -141,6 +162,10 @@ pytest
 ## Troubleshooting
 
 If you run into errors or need help debugging, see the [Common Issues guide](docs/guides/troubleshooting/common-issues.md).
+For performance tuning tips see [Performance Optimization](docs/guides/performance-optimization.md).
+Review the [Legal Compliance](docs/legal-compliance.md) guidelines before going live.
+
+
 
 
 ## Phase 2 Complete

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,8 @@ Complete guides for all PAM features and capabilities:
 - [Integration Patterns](technical/integration-patterns.md) - Integration guidelines
 - [Security Considerations](technical/security-considerations.md) - Security practices
 - [PAM Backend Deployment](technical/pam-backend-deployment.md) - Backend deployment progress
+- [Performance Optimization](guides/performance-optimization.md) - Tuning tips
+- [Legal Compliance](legal-compliance.md) - Data privacy guidelines
 
 ## 🚀 Quick Start
 

--- a/docs/deployment/production-deployment.md
+++ b/docs/deployment/production-deployment.md
@@ -1,0 +1,27 @@
+# Production Deployment Guide
+
+This document explains how to deploy Wheels & Wins to a production environment.
+
+## Prerequisites
+- Docker installed on the target server
+- Access to environment variables and secrets
+- Domain name configured to point to the server
+
+## Steps
+1. **Clone the repository** on the production host:
+   ```bash
+   git clone https://github.com/your-org/wheels-wins-landing-page.git
+   cd wheels-wins-landing-page
+   ```
+2. **Create a `.env.production` file** with the necessary variables (see [environment-variables](environment-variables.md)).
+3. **Build and start the containers** using the provided compose file:
+   ```bash
+   docker-compose -f docker-compose.prod.yml up -d
+   ```
+4. **Verify** the service is running by visiting `https://your-domain.com/health`.
+5. **Monitor** logs with:
+   ```bash
+   docker-compose -f docker-compose.prod.yml logs -f
+   ```
+
+This basic workflow can be adapted to other hosts such as Render or Railway. For advanced configuration, consult `backend/docs/DEPLOYMENT_GUIDE.md`.

--- a/docs/guides/performance-optimization.md
+++ b/docs/guides/performance-optimization.md
@@ -1,0 +1,22 @@
+# Performance Optimization Recommendations
+
+These guidelines outline best practices for keeping the Wheels & Wins application fast and efficient.
+
+## Frontend
+- Enable code splitting in Vite to reduce initial bundle size.
+- Serve static assets with long cache headers.
+- Use lazy loading for heavy components and images.
+- Monitor React component renders with the React DevTools profiler.
+
+## Backend
+- Use async database operations via SQLAlchemy asyncio to maximize throughput.
+- Cache expensive API calls using Redis with sensible TTLs.
+- Profile API endpoints and refactor any slow queries.
+- Enable gzip compression in your reverse proxy (Nginx).
+
+## Database
+- Ensure indexes exist on frequently queried columns such as `user_id` and timestamp fields.
+- Use connection pooling to minimize connection overhead.
+- Regularly run `ANALYZE` and `VACUUM` on large tables.
+
+Following these recommendations will help the application scale while keeping response times low.

--- a/docs/guides/troubleshooting/common-issues.md
+++ b/docs/guides/troubleshooting/common-issues.md
@@ -165,3 +165,4 @@ npm run build --verbose
    - [API Errors](api-errors.md)
    - [Debugging Guide](debugging-guide.md)
    - [Deployment Issues](deployment-issues.md)
+   - [Performance Optimization](../performance-optimization.md)

--- a/docs/legal-compliance.md
+++ b/docs/legal-compliance.md
@@ -1,0 +1,25 @@
+# Legal Compliance Guidelines
+
+This project collects and processes user data. Follow these guidelines to ensure compliance with data protection laws such as GDPR and CCPA.
+
+## Data Protection Principles
+- Collect only data that is necessary for application features.
+- Store personal data securely using encryption for sensitive fields.
+- Provide users with access and deletion requests via support channels.
+- Do not retain data longer than required for the stated purpose.
+
+## User Consent
+- Obtain explicit consent before storing personal information or tracking analytics.
+- Present a clear privacy policy describing how data is used.
+- Allow users to withdraw consent at any time through account settings.
+
+## Third-Party Services
+- Review the privacy policies of all integrated services (OpenAI, Supabase, etc.).
+- Ensure data transfers comply with international regulations.
+- Sign Data Processing Agreements (DPAs) with providers when available.
+
+## Incident Response
+- Notify affected users within 72 hours of discovering a data breach.
+- Document remediation steps and maintain incident logs.
+
+Following these practices helps protect user privacy and keeps the project compliant with relevant legislation.

--- a/docs/technical/api-documentation.md
+++ b/docs/technical/api-documentation.md
@@ -11,6 +11,17 @@ Complete reference for the PAM Backend API endpoints, authentication, and integr
 **Content-Type**: `application/json`  
 **Authentication**: Bearer Token (JWT)
 
+### Modules Overview
+The API is organized into the following modules:
+
+| Module | Key Endpoints |
+| ------ | ------------- |
+| Authentication | `/auth/login`, `/auth/refresh`, `/auth/logout` |
+| Budgets | `/budgets`, `/budgets/{id}` |
+| Expenses | `/expenses`, `/expenses/{id}` |
+| Vehicles | `/vehicles`, `/vehicles/{id}` |
+| Trips | `/trips`, `/trips/{id}` |
+
 ## Authentication
 
 ### Overview

--- a/examples/api_example.py
+++ b/examples/api_example.py
@@ -1,0 +1,15 @@
+import os
+import requests
+
+BASE_URL = os.getenv("API_BASE_URL", "http://localhost:8000/api")
+TOKEN = os.getenv("API_TOKEN")
+
+headers = {
+    "Authorization": f"Bearer {TOKEN}" if TOKEN else "",
+    "Content-Type": "application/json",
+}
+
+# Example: fetch budgets for current user
+resp = requests.get(f"{BASE_URL}/budgets", headers=headers)
+print("Status:", resp.status_code)
+print(resp.json())

--- a/examples/setup_env.sh
+++ b/examples/setup_env.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Example environment setup script
+export API_BASE_URL="https://pam-backend.onrender.com/api"
+export API_TOKEN="your_jwt_token_here"
+
+# Run an example API call
+python api_example.py


### PR DESCRIPTION
## Summary
- document setup instructions in the main README
- add links to new docs in `docs/README.md`
- include a production deployment guide
- provide performance optimization tips and legal compliance guidelines
- link troubleshooting guide to optimization docs
- expand API docs with module overview
- add example usage scripts under `examples/`

## Testing
- `npm test`
- `pytest -q` *(fails: openai.OpenAIError, DidNotEnable: SQLAlchemy not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687b2d3edee483238503bc51940a4427