### PR TITLE
Implement backend alert retrieval

### DIFF
--- a/src/components/admin/pam-analytics/hooks/useRealTimeAlerts.ts
+++ b/src/components/admin/pam-analytics/hooks/useRealTimeAlerts.ts
@@ -1,7 +1,7 @@
 
 import { useState, useEffect } from 'react';
 import { useToast } from '@/hooks/use-toast';
-import { supabase } from '@/integrations/supabase/client';
+import { apiFetch } from '@/services/api';
 
 export interface Alert {
   id: string;
@@ -16,76 +16,18 @@ export const useRealTimeAlerts = () => {
   const [alerts, setAlerts] = useState<Alert[]>([]);
   const { toast } = useToast();
 
-  // TODO: Remove this fallback once the backend returns real alerts
-  const mockAlerts: Alert[] = [
-    {
-      id: '1',
-      type: 'warning',
-      title: 'High Error Rate',
-      message: 'Error rate has increased to 4.2% in the last hour',
-      timestamp: new Date().toISOString(),
-      acknowledged: false
-    },
-    {
-      id: '2',
-      type: 'info',
-      title: 'Peak Usage',
-      message: 'Current usage is 150% above average for this time',
-      timestamp: new Date(Date.now() - 300000).toISOString(),
-      acknowledged: false
-    }
-  ];
 
   const fetchAlerts = async () => {
     try {
-      // Get recent system events and errors to generate alerts
-      const { data: agentLogs, error } = await supabase
-        .from('agent_logs')
-        .select('*')
-        .order('created_at', { ascending: false })
-        .limit(100);
-
-      if (error) throw error;
-
-      const recentLogs = agentLogs?.filter(log => {
-        const logTime = new Date(log.created_at);
-        const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
-        return logTime >= oneHourAgo;
-      }) || [];
-
-      const generatedAlerts: Alert[] = [];
-
-      // Generate alert for high activity
-      if (recentLogs.length > 50) {
-        generatedAlerts.push({
-          id: 'high-activity',
-          type: 'info',
-          title: 'High Activity Detected',
-          message: `${recentLogs.length} requests in the last hour (above normal)`,
-          timestamp: new Date().toISOString(),
-          acknowledged: false
-        });
+      const response = await apiFetch('/api/alerts/status');
+      if (!response.ok) {
+        throw new Error('Failed to fetch alerts');
       }
-
-      // Generate alert for memory usage
-      const memoryUsageCount = recentLogs.filter(log => log.memory_used).length;
-      if (memoryUsageCount > recentLogs.length * 0.8) {
-        generatedAlerts.push({
-          id: 'high-memory',
-          type: 'warning',
-          title: 'High Memory Usage',
-          message: `${Math.round((memoryUsageCount / recentLogs.length) * 100)}% of requests using memory lookup`,
-          timestamp: new Date().toISOString(),
-          acknowledged: false
-        });
-      }
-
-      // If no real alerts, use a subset of mock alerts
-      setAlerts(generatedAlerts.length > 0 ? generatedAlerts : mockAlerts.slice(0, 1));
+      const data = await response.json();
+      setAlerts(data.alerts ?? []);
     } catch (error: any) {
       console.error('Failed to fetch alerts:', error);
-      // Fallback to mock alerts on error
-      setAlerts(mockAlerts);
+      setAlerts([]);
     }
   };
 


### PR DESCRIPTION
## Summary
- fetch real alerts from `/api/alerts/status`
- remove mock data from useRealTimeAlerts

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687b50bad3e883238a3b9b8b79cc10a3