### PR TITLE
Add missing onboarding API endpoint

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -17,6 +17,7 @@ from . import (
     orders,
     maintenance,
     custom_routes,
+    onboarding,
     mapbox,
     user_settings,
 )
@@ -40,6 +41,7 @@ __all__ = [
     'orders',
     'maintenance',
     'custom_routes',
+    'onboarding',
     'mapbox',
     'user_settings',
 ]

--- a/backend/app/api/v1/onboarding.py
+++ b/backend/app/api/v1/onboarding.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter, HTTPException
+
+from app.agents.pam.onboarding import handle_onboarding
+
+router = APIRouter()
+
+@router.post("/onboarding")
+async def submit_onboarding(payload: dict):
+    """Accept onboarding data from the frontend and store it via PAM."""
+    result = handle_onboarding(payload)
+    if result.startswith("Error"):
+        raise HTTPException(status_code=400, detail=result)
+    return {"message": result}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -61,6 +61,7 @@ from app.api.v1 import (
     custom_routes,
     mapbox,
     user_settings,
+    onboarding,
 )
 from app.api.v1 import observability as observability_api
 from app.api import websocket, actions
@@ -339,6 +340,7 @@ app.include_router(products.router, prefix="/api/v1", tags=["Products"])
 app.include_router(orders.router, prefix="/api/v1", tags=["Orders"])
 app.include_router(maintenance.router, prefix="/api/v1", tags=["Maintenance"])
 app.include_router(custom_routes.router, prefix="/api/v1", tags=["Routes"])
+app.include_router(onboarding.router, prefix="/api/v1", tags=["Onboarding"])
 # Removed generic websocket router to avoid conflicts with PAM WebSocket
 # app.include_router(websocket.router, prefix="/api", tags=["WebSocket"])
 app.include_router(auth.router, prefix="/api/auth", tags=["Authentication"])

--- a/backend/requirements-test.txt
+++ b/backend/requirements-test.txt
@@ -34,4 +34,4 @@ pytest-json-report==1.5.0
 locust==2.20.0
 
 # Include main dependencies for test environment
--r requirements.txtpytest-asyncio==0.21.1
+-r requirements.txt

--- a/tests/test_onboarding_api.py
+++ b/tests/test_onboarding_api.py
@@ -1,0 +1,42 @@
+import os
+import sys
+from pathlib import Path
+import pytest
+from httpx import AsyncClient
+
+backend_path = Path(__file__).resolve().parent.parent / "backend"
+if str(backend_path) not in sys.path:
+    sys.path.insert(0, str(backend_path))
+
+from app.main import app
+
+if os.getenv("RUN_API_TESTS") != "1":
+    pytest.skip("Skipping API tests", allow_module_level=True)
+
+@pytest.fixture
+async def test_client() -> AsyncClient:
+    async with AsyncClient(app=app, base_url="http://test") as client:
+        yield client
+
+@pytest.mark.asyncio
+async def test_onboarding_endpoint(test_client: AsyncClient):
+    payload = {
+        "full_name": "Jane Doe",
+        "nickname": "jane",
+        "email": "jane@example.com",
+        "region": "US",
+        "travel_style": "solo",
+        "vehicle_type": "RV",
+        "make_model_year": "2020",
+        "fuel_type": "diesel",
+        "daily_drive_limit": "100",
+        "towing_info": "none",
+        "second_vehicle": "none",
+        "preferred_camp_types": "RV Park",
+        "pet_info": "none",
+        "accessibility_needs": "none",
+        "age_range": "30-40",
+    }
+    response = await test_client.post("/api/v1/onboarding", json=payload)
+    assert response.status_code == 200
+    assert "successfully" in response.json().get("message", "")


### PR DESCRIPTION
## Summary
- create `/api/v1/onboarding` route
- register onboarding router in API package and main app
- fix requirements-test formatting
- add basic test for onboarding endpoint

## Testing
- `npm test` *(fails: No test files found)*
- `pip install -r backend/requirements-test.txt` *(fails: dependency conflict)*
- `pytest -q` *(fails: ModuleNotFoundError: pydantic_settings)*

------
https://chatgpt.com/codex/tasks/task_e_68807a21f75083238afad81d2e056c5c