### PR TITLE
Remove custom CORS handler

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -324,19 +324,15 @@ async def root():
         "updated": "2025-07-10T06:45:00Z",
     }
 
-# Global CORS OPTIONS handler - catches all OPTIONS requests
-@app.options("/{full_path:path}")
-async def options_handler(full_path: str):
-    """Global OPTIONS handler for CORS preflight requests"""
-    return Response(
-        status_code=200,
-        headers={
-            "Access-Control-Allow-Origin": "*",
-            "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS, PATCH",
-            "Access-Control-Allow-Headers": "Authorization, Content-Type, Accept, X-Requested-With, Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
-            "Access-Control-Max-Age": "86400"
-        }
-    )
+
+# The CORSMiddleware added above automatically handles all CORS preflight
+# requests.  A custom global OPTIONS handler previously overrode this
+# behaviour and returned wildcard CORS headers.  This caused the frontend to
+# receive responses without the appropriate `Access-Control-Allow-Origin`
+# header, breaking cross-origin requests.  Removing the route allows
+# CORSMiddleware to apply the configured `cors_origins` list and return the
+# correct headers for `https://wheelsandwins.com` and other allowed origins.
+
 
 # Include API routers
 app.include_router(


### PR DESCRIPTION
## Summary
- let FastAPI CORSMiddleware handle preflight requests by removing the custom OPTIONS route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for several dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688701d0b7f083239a00724b2983e803