### PR TITLE
Add OPENAI_API_KEY property to UnifiedSettings

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -61,6 +61,10 @@ class UnifiedSettings:
     @property
     def SUPABASE_KEY(self) -> str:
         return self.infra.SUPABASE_KEY
+
+    @property
+    def OPENAI_API_KEY(self) -> str | None:
+        return self.infra.OPENAI_API_KEY
     
     # TTS settings (from user)
     @property

--- a/docs/guides/development/code-structure.md
+++ b/docs/guides/development/code-structure.md
@@ -250,6 +250,10 @@ class UnifiedSettings:
     @property
     def TTS_ENABLED(self) -> bool:
         return self.user.TTS_ENABLED
+
+    @property
+    def OPENAI_API_KEY(self) -> str | None:
+        return self.infra.OPENAI_API_KEY
     
     # Feature checking
     def is_feature_enabled(self, feature_name: str, user_id: str = None) -> bool:

--- a/docs/technical/backend-simplification.md
+++ b/docs/technical/backend-simplification.md
@@ -100,6 +100,10 @@ class UnifiedSettings:
     @property
     def SUPABASE_URL(self) -> str:
         return self.infra.SUPABASE_URL
+
+    @property
+    def OPENAI_API_KEY(self) -> str | None:
+        return self.infra.OPENAI_API_KEY
 ```
 
 ## Phase 2: Shared Utilities Extraction


### PR DESCRIPTION
## Summary
- expose `OPENAI_API_KEY` through `UnifiedSettings`
- document the new property in code structure and backend simplification guides

## Testing
- `npm run quality:check` *(fails: 16 errors, 188 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688725f26bcc832392ad0291806fce31