### PR TITLE
Add CORS and health endpoint to fallback app

### DIFF
--- a/simple_tests/test_app_fallback.py
+++ b/simple_tests/test_app_fallback.py
@@ -1,0 +1,31 @@
+import importlib
+import importlib.util
+from pathlib import Path
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+
+spec = importlib.util.spec_from_file_location("root_app", ROOT / "app.py")
+app_module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(app_module)
+import sys
+sys.modules[spec.name] = app_module
+
+
+def test_fallback_cors_and_health(monkeypatch):
+    monkeypatch.setenv("CORS_ORIGINS", "http://example.com")
+
+    def fail_load():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(app_module, "_load_backend_app", fail_load)
+    spec.loader.exec_module(app_module)
+
+    client = TestClient(app_module.app)
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "error"
+
+    assert any(m.cls is CORSMiddleware for m in app_module.app.user_middleware)

--- a/simple_tests/test_math_utils.py
+++ b/simple_tests/test_math_utils.py
@@ -1,4 +1,9 @@
 import pytest
+import sys
+from pathlib import Path
+
+# Ensure backend package is importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "backend"))
 
 from app.utils.math_utils import add, subtract, multiply, divide
 


### PR DESCRIPTION
## Summary
- extend fallback FastAPI initialization in `app.py` to include `CORSMiddleware`
- expose lightweight `/health` endpoint when backend import fails
- add regression test for fallback behaviour
- fix import path for math utils tests

## Testing
- `pytest simple_tests/test_app_fallback.py simple_tests/test_math_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688726f7fd0c8323849a6b0b4c470021