### PR TITLE
fix: restore legacy result key for PAM tools

### DIFF
--- a/backend/app/services/pam/tools/base_tool.py
+++ b/backend/app/services/pam/tools/base_tool.py
@@ -24,6 +24,9 @@ class ToolResult:
         return {
             "success": self.success,
             "data": self.data,
+            # Maintain backward compatibility for callers expecting a
+            # ``result`` field while aligning with the newer ``data`` key.
+            "result": self.data,
             "error": self.error,
             "metadata": self.metadata or {}
         }


### PR DESCRIPTION
## Summary
- add a legacy `result` alias to the PAM `ToolResult.to_dict` response
- keep the existing `data` field so both access patterns continue to work

## Testing
- pytest backend/app/tests/test_receipts.py *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68cf4b83bde483238d7d6648e4cace94