### PR TITLE
feat: enable tool forwarding for AI orchestrator

### DIFF
--- a/backend/tests/unit/test_ai_orchestrator_function_calling.py
+++ b/backend/tests/unit/test_ai_orchestrator_function_calling.py
@@ -1,0 +1,90 @@
+from typing import Any, Dict, List, Optional, Tuple
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.ai.ai_orchestrator import AIOrchestrator
+from app.services.ai.provider_interface import (
+    AICapability,
+    AIMessage,
+    AIProviderInterface,
+    AIProviderStatus,
+    AIResponse,
+    ProviderConfig,
+)
+from app.services.ai.ai_orchestrator import ProviderMetrics
+
+
+class DummyProvider(AIProviderInterface):
+    def __init__(self, name: str, supports_function_calling: bool, should_fail: bool = False):
+        config = ProviderConfig(name=name, api_key="test-key", default_model="gpt-test")
+        if supports_function_calling:
+            config.capabilities.append(AICapability.FUNCTION_CALLING)
+        super().__init__(config)
+        self.should_fail = should_fail
+        self.complete_calls: List[Dict[str, Any]] = []
+
+    async def complete(
+        self,
+        messages: List[AIMessage],
+        model: Optional[str] = None,
+        temperature: float = 0.7,
+        max_tokens: Optional[int] = None,
+        **kwargs,
+    ) -> AIResponse:
+        self.complete_calls.append(kwargs)
+        if self.should_fail:
+            raise RuntimeError("failure")
+        return AIResponse(
+            content="ok",
+            model=model or self.config.default_model,
+            provider=self.name,
+            usage={"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+            latency_ms=1.0,
+            finish_reason="stop",
+        )
+
+    async def stream(self, *args, **kwargs):
+        raise NotImplementedError
+
+    async def health_check(self) -> Tuple[AIProviderStatus, Optional[str]]:
+        return AIProviderStatus.HEALTHY, None
+
+
+@pytest.mark.asyncio
+async def test_functions_only_forwarded_to_capable_providers():
+    orchestrator = AIOrchestrator()
+    capable_provider = DummyProvider("capable", supports_function_calling=True, should_fail=True)
+    fallback_provider = DummyProvider("fallback", supports_function_calling=False)
+
+    orchestrator.providers = [capable_provider, fallback_provider]
+    orchestrator._initialized = True
+    orchestrator.provider_metrics = {
+        "capable": ProviderMetrics(
+            provider_name="capable",
+            success_rate=1.0,
+            average_latency_ms=0.0,
+            cost_per_token=0.0,
+            last_used=0.0,
+            consecutive_failures=0,
+        ),
+        "fallback": ProviderMetrics(
+            provider_name="fallback",
+            success_rate=1.0,
+            average_latency_ms=0.0,
+            cost_per_token=0.0,
+            last_used=0.0,
+            consecutive_failures=0,
+        ),
+    }
+
+    orchestrator._select_providers = AsyncMock(return_value=[capable_provider, fallback_provider])
+
+    response = await orchestrator.complete(
+        messages=[AIMessage(role="user", content="hi")],
+        functions=[{"name": "tool", "description": ""}]
+    )
+
+    assert response.provider == "fallback"
+    assert capable_provider.complete_calls[0]["functions"] == [{"name": "tool", "description": ""}]
+    assert "functions" not in fallback_provider.complete_calls[0]

--- a/backend/tests/unit/test_enhanced_orchestrator_function_calling.py
+++ b/backend/tests/unit/test_enhanced_orchestrator_function_calling.py
@@ -1,0 +1,122 @@
+import json
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.models.domain.pam import PamContext
+from app.services.ai.provider_interface import AIResponse, AICapability
+from app.services.pam.enhanced_orchestrator import (
+    EnhancedPamContext,
+    EnhancedPamOrchestrator,
+    ResponseMode,
+)
+from app.services.pam.tools.tool_registry import ToolExecutionResult
+
+
+@pytest.mark.asyncio
+async def test_tool_call_triggers_registry_and_supabase_data():
+    orchestrator = EnhancedPamOrchestrator()
+
+    mock_ai_orchestrator = MagicMock()
+    tool_definitions = [
+        {
+            "name": "manage_finances",
+            "description": "Manage budgets",
+            "parameters": {},
+        }
+    ]
+
+    supabase_payload = {
+        "summary": {"total_expenses": 250.0, "currency": "USD"},
+        "success": True,
+    }
+
+    mock_tool_registry = SimpleNamespace()
+    mock_tool_registry.get_openai_functions = MagicMock(return_value=tool_definitions)
+    mock_tool_registry.execute_tool = AsyncMock(
+        return_value=ToolExecutionResult(
+            success=True,
+            tool_name="manage_finances",
+            execution_time_ms=12.0,
+            result=supabase_payload,
+        )
+    )
+
+    first_response = AIResponse(
+        content="",
+        model="gpt-5",
+        provider="openai",
+        usage={"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+        latency_ms=10.0,
+        finish_reason="function_call",
+        function_calls=[
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                    "name": "manage_finances",
+                    "arguments": json.dumps({"action": "fetch_summary"}),
+                },
+            }
+        ],
+    )
+
+    followup_response = AIResponse(
+        content="Here is your recent spending.",
+        model="gpt-5",
+        provider="openai",
+        usage={"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+        latency_ms=8.0,
+        finish_reason="stop",
+    )
+
+    mock_ai_orchestrator.complete = AsyncMock(
+        side_effect=[first_response, followup_response]
+    )
+
+    orchestrator.ai_orchestrator = mock_ai_orchestrator
+    orchestrator.tool_registry = mock_tool_registry
+
+    pam_context = PamContext(user_id="user-1", timestamp=datetime.utcnow())
+    enhanced_context = EnhancedPamContext(
+        base_context=pam_context,
+        knowledge_available=False,
+        tts_available=False,
+        voice_streaming_active=False,
+        user_location=None,
+        preferred_response_mode=ResponseMode.TEXT_ONLY,
+        service_capabilities={},
+        conversation_mode="text",
+        quality_requirements={},
+    )
+
+    result = await orchestrator._process_with_ai_service(
+        message="How much have I spent on fuel this month?",
+        enhanced_context=enhanced_context,
+        user_id="user-1",
+        session_id="session-1",
+    )
+
+    complete_mock = orchestrator.ai_orchestrator.complete
+    first_call = complete_mock.await_args_list[0]
+
+    assert first_call.kwargs["functions"] == tool_definitions
+    assert AICapability.FUNCTION_CALLING in first_call.kwargs["required_capabilities"]
+
+    second_call = complete_mock.await_args_list[1]
+    assert "functions" not in second_call.kwargs
+    tool_context_message = second_call.kwargs["messages"][1].content
+    assert "\"total_expenses\": 250.0" in tool_context_message
+
+    orchestrator.tool_registry.execute_tool.assert_awaited_once_with(
+        tool_name="manage_finances",
+        user_id="user-1",
+        parameters={"action": "fetch_summary"},
+        timeout=30,
+    )
+
+    assert result["content"] == followup_response.content
+    assert result["ai_metadata"]["tool_results"]["manage_finances"]["result"] == supabase_payload
+    assert "tools" in result.get("capabilities_used", [])


### PR DESCRIPTION
## Summary
- forward orchestrator tool definitions to AI providers and capture tool execution metadata in responses
- update AI orchestrator and OpenAI wrapper to request function-calling support only when available and normalize tool call payloads
- add unit tests verifying tool execution paths use Supabase-backed data and that tool payloads are skipped for providers without capability

## Testing
- pytest backend/tests/unit/test_enhanced_orchestrator_function_calling.py backend/tests/unit/test_ai_orchestrator_function_calling.py

------
https://chatgpt.com/codex/tasks/task_e_68cf56803e9c8323a202d52b14ca985f