### PR TITLE
Improve PAM session token handling for authenticated tools

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -4,6 +4,7 @@ import type { User as SupabaseUser, Session } from '@supabase/supabase-js';
 import { recordLogin, endSession } from '@/lib/authLogging';
 import { setUser as setSentryUser, setTag, captureMessage } from '@/lib/sentry';
 import { AuthErrorHandler, AuthError, AuthErrorType } from '@/utils/authErrorHandler';
+import { authSessionManager } from '@/context/authSessionManager';
 
 interface User {
   id: string;
@@ -130,6 +131,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           const previousSession = session;
           setSession(session);
           setToken(session?.access_token || null);
+          authSessionManager.setSession(session || null);
           
           console.log('[AuthContext] Session updated:', {
             hadSession: !!previousSession,
@@ -181,6 +183,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       
       setSession(session);
       setToken(session?.access_token || null);
+      authSessionManager.setSession(session || null);
       
       if (session?.user) {
         const userData = {
@@ -345,6 +348,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setUser(null);
       setSession(null);
       setToken(null);
+      authSessionManager.clearSession();
 
       // Clear Sentry user context
       setSentryUser(null);

--- a/src/context/authSessionManager.ts
+++ b/src/context/authSessionManager.ts
@@ -1,0 +1,82 @@
+import type { Session } from '@supabase/supabase-js';
+
+const STORAGE_KEY = 'pam-auth-token';
+
+interface StoredSessionPayload {
+  currentSession?: Session | null;
+  expiresAt?: number | null;
+}
+
+let cachedSession: Session | null = null;
+let cachedToken: string | null = null;
+let hydratedFromStorage = false;
+
+const hydrateFromStorage = () => {
+  if (hydratedFromStorage || typeof window === 'undefined') {
+    return;
+  }
+
+  hydratedFromStorage = true;
+
+  try {
+    let raw = window.localStorage.getItem(STORAGE_KEY);
+
+    if (!raw) {
+      for (let index = 0; index < window.localStorage.length; index += 1) {
+        const key = window.localStorage.key(index);
+        if (key && key.startsWith('sb-') && key.endsWith('-auth-token')) {
+          raw = window.localStorage.getItem(key);
+          if (raw) {
+            break;
+          }
+        }
+      }
+    }
+
+    if (!raw) {
+      return;
+    }
+
+    const parsed = JSON.parse(raw) as StoredSessionPayload | undefined;
+    const session = parsed?.currentSession;
+
+    if (session?.access_token) {
+      cachedSession = session;
+      cachedToken = session.access_token;
+    }
+  } catch (error) {
+    console.warn('[AuthSessionManager] Failed to hydrate session from storage:', error);
+  }
+};
+
+export const authSessionManager = {
+  setSession(session: Session | null) {
+    hydratedFromStorage = true;
+    cachedSession = session;
+    cachedToken = session?.access_token ?? null;
+  },
+
+  clearSession() {
+    hydratedFromStorage = true;
+    cachedSession = null;
+    cachedToken = null;
+  },
+
+  getSession(): Session | null {
+    if (!cachedSession) {
+      hydrateFromStorage();
+    }
+    return cachedSession;
+  },
+
+  getToken(): string | null {
+    if (!cachedToken) {
+      hydrateFromStorage();
+    }
+    return cachedToken;
+  },
+
+  getUserId(): string | null {
+    return this.getSession()?.user?.id ?? null;
+  }
+};


### PR DESCRIPTION
## Summary
- add an `authSessionManager` helper to hydrate Supabase sessions from storage and cache access tokens for reuse
- update `AuthContext` to keep the shared manager in sync on sign-in, initial load, and sign-out events
- switch PAM agentic and savings services to pull tokens from the manager so authenticated tools work even when direct Supabase session calls fail

## Testing
- npm run lint *(fails: existing lint/parse errors in legacy backup directories)*
- npx eslint src/context/AuthContext.tsx src/services/pamAgenticService.ts src/services/pamSavingsService.ts src/context/authSessionManager.ts


------
https://chatgpt.com/codex/tasks/task_e_68cfac740f1c832392ab3f370ba17353