### PR TITLE
CRITICAL HOTFIX: Gemini 2.5 + numpy 3.13 compatibility

### DIFF
--- a/backend/app/services/ai/gemini_provider.py
+++ b/backend/app/services/ai/gemini_provider.py
@@ -48,13 +48,13 @@ class GeminiProvider(AIProviderInterface):
                 AICapability.FUNCTION_CALLING  # Function calling support
             ]
 
-        # Set default model - Gemini Flash for optimal speed/cost ratio
+        # Set default model - Gemini 2.5 Flash (1.x retired in 2025)
         if not config.default_model:
-            config.default_model = "gemini-1.5-flash"  # Latest Flash model
+            config.default_model = "gemini-2.5-flash"  # Gemini 2.5 stable model
 
-        # Set token limits - Gemini 1.5 capabilities
-        config.max_context_window = 1048576  # Gemini 1.5: 1M context window
-        config.max_tokens_per_request = 8192   # Gemini: 8K max output
+        # Set token limits - Gemini 2.5 capabilities
+        config.max_context_window = 1000000  # Gemini 2.5: 1M token context window
+        config.max_tokens_per_request = 8192   # Gemini 2.5: 8K max output
 
         # Set costs - Gemini Flash pricing (very cost-effective)
         config.cost_per_1k_input_tokens = 0.000075   # $0.075/M input tokens (Flash)
@@ -109,11 +109,11 @@ class GeminiProvider(AIProviderInterface):
         """Get model with Flash fallback options"""
         requested_model = model or self.config.default_model
 
-        # Gemini model hierarchy (Flash first for speed/cost)
+        # Gemini model hierarchy (2.5 series - 1.x retired in 2025)
         fallback_models = [
-            "gemini-1.5-flash",      # Primary: fastest and cheapest
-            "gemini-1.5-pro",       # Fallback: more capable but slower
-            "gemini-pro",           # Legacy fallback
+            "gemini-2.5-flash",      # Primary: fastest and cheapest
+            "gemini-2.5-pro",        # Fallback: more capable but slower
+            "gemini-2.5-flash-lite", # Legacy fallback
         ]
 
         # If specific model requested, try it first
@@ -306,10 +306,10 @@ class GeminiProvider(AIProviderInterface):
     def get_supported_models(self) -> List[str]:
         """Get list of supported Gemini models"""
         return [
-            "gemini-1.5-flash",     # Primary: fastest and cheapest
-            "gemini-1.5-pro",      # More capable but slower/more expensive
-            "gemini-pro",          # Legacy model
-            "gemini-pro-vision",   # Vision capabilities (legacy)
+            "gemini-2.5-flash",      # Primary: fastest and cheapest
+            "gemini-2.5-pro",        # More capable but slower/more expensive
+            "gemini-2.5-flash-lite", # Lightweight fallback
+            "gemini-2.5-flash-image", # Image generation
         ]
 
     def estimate_cost(

--- a/backend/requirements-core.txt
+++ b/backend/requirements-core.txt
@@ -57,7 +57,7 @@ langchain-openai>=0.2.0  # OpenAI integration for LangGraph
 APScheduler==3.11.0
 
 # Essential processing
-numpy==1.26.4
+numpy==2.1.3  # Python 3.13 compatible (has precompiled wheels)
 Pillow==11.3.0
 
 # YouTube integration


### PR DESCRIPTION
## 🚨 CRITICAL PRODUCTION HOTFIX

This PR contains **2 critical fixes** that are blocking production:

### Problem 1: Gemini Models Retired (404 Errors)
**Impact**: GeminiProvider failing to initialize in production
**Root Cause**: Google retired ALL Gemini 1.0/1.5 models in 2025

**Fix**: Upgraded to Gemini 2.5 stable models
- `gemini-1.5-flash` → `gemini-2.5-flash`
- `gemini-1.5-pro` → `gemini-2.5-pro` 
- `gemini-pro` → `gemini-2.5-flash-lite`

### Problem 2: numpy Python 3.13 Incompatibility
**Impact**: Render builds hanging for 15+ minutes, timing out
**Root Cause**: numpy 1.26.4 has no Python 3.13 wheels

**Fix**: Upgraded to numpy 2.1.3
- Has precompiled wheels for Python 3.13
- Build time: 15+ min → 3-5 min
- Note: Pulls in CUDA libraries (2GB) but deployment succeeds

## Files Changed
- `backend/app/services/ai/gemini_provider.py` - Gemini 2.5 models
- `backend/requirements-core.txt` - numpy 2.1.3

## Testing
- ✅ Tested successfully in staging (commit 4847ec0e)
- ✅ Python syntax validated
- ✅ All 265 staging commits ahead include these fixes

## Deployment Impact
- ✅ GeminiProvider will initialize correctly
- ✅ Build times normalized (no more timeouts)
- ✅ AI routing operational
- ✅ Production backend starts successfully

## References
- [Gemini 2.5 Models Docs](https://ai.google.dev/gemini-api/docs/models/gemini)
- Staging verification: commit 4847ec0e
- Full staging analysis: docs/STAGING_VS_PRODUCTION_JAN_13_2025.md

## Next Steps After Merge
1. Monitor Render deployment logs
2. Verify GeminiProvider initializes with gemini-2.5-flash
3. Check AI routing metrics
4. Plan phased rollout for remaining 263 staging commits