### PR TITLE
fix: add rpc helper for transition profile setup

### DIFF
--- a/src/components/you/__tests__/TransitionNavigatorCard.test.tsx
+++ b/src/components/you/__tests__/TransitionNavigatorCard.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { TransitionNavigatorCard } from '../TransitionNavigatorCard';
+import type { TransitionProfile } from '@/types/transition.types';
+
+const mockUseAuth = vi.fn();
+const mockUseTransitionModule = vi.fn();
+const rpcMock = vi.fn();
+const toastSuccessMock = vi.fn();
+const toastErrorMock = vi.fn();
+const navigateMock = vi.fn();
+
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+vi.mock('@/hooks/useTransitionModule', () => ({
+  useTransitionModule: () => mockUseTransitionModule(),
+}));
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { rpc: (...args: unknown[]) => rpcMock(...args) },
+  default: { rpc: (...args: unknown[]) => rpcMock(...args) },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccessMock(...args),
+    error: (...args: unknown[]) => toastErrorMock(...args),
+  },
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+describe('TransitionNavigatorCard', () => {
+  beforeEach(() => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 'user-123', email: 'user@example.com' },
+    });
+
+    mockUseTransitionModule.mockReturnValue({
+      isEnabled: false,
+      isLoading: false,
+      profile: null,
+      shouldShowInNav: false,
+      daysUntilDeparture: null,
+    });
+
+    rpcMock.mockReset();
+    toastSuccessMock.mockReset();
+    toastErrorMock.mockReset();
+    navigateMock.mockReset();
+  });
+
+  afterEach(() => {
+    mockUseAuth.mockReset();
+    mockUseTransitionModule.mockReset();
+  });
+
+  it('calls RPC to start transition profile and navigates on success', async () => {
+    const profile: TransitionProfile = {
+      id: 'profile-1',
+      user_id: 'user-123',
+      departure_date: '2025-04-01',
+      current_phase: 'planning',
+      transition_type: 'full_time',
+      motivation: null,
+      concerns: [],
+      is_enabled: true,
+      auto_hide_after_departure: true,
+      hide_days_after_departure: 30,
+      completion_percentage: 0,
+      last_milestone_reached: null,
+      created_at: '2025-01-01T12:00:00Z',
+      updated_at: '2025-01-01T12:00:00Z',
+      archived_at: null,
+    };
+
+    rpcMock.mockResolvedValue({ data: profile, error: null });
+
+    render(<TransitionNavigatorCard />);
+
+    const startButton = screen.getByRole('button', { name: /start planning my transition/i });
+    const baseDate = new Date();
+    await userEvent.click(startButton);
+
+    const expectedDate = new Date(baseDate);
+    expectedDate.setDate(expectedDate.getDate() + 90);
+    const expectedDateString = expectedDate.toISOString().slice(0, 10);
+
+    await waitFor(() => {
+      expect(rpcMock).toHaveBeenCalledWith('start_transition_profile', {
+        p_departure_date: expectedDateString,
+        p_is_enabled: true,
+      });
+    });
+
+    expect(toastSuccessMock).toHaveBeenCalledWith("Let's start planning your transition!");
+    expect(navigateMock).toHaveBeenCalledWith('/transition');
+  });
+
+  it('shows permission guidance when RPC returns RLS error', async () => {
+    rpcMock.mockResolvedValue({ data: null, error: { code: '42501', message: 'permission denied' } });
+
+    render(<TransitionNavigatorCard />);
+
+    const startButton = screen.getByRole('button', { name: /start planning my transition/i });
+    await userEvent.click(startButton);
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith('Still missing permission to create your transition profile');
+    });
+
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it('requires login before starting planning', async () => {
+    mockUseAuth.mockReturnValue({ user: null });
+
+    render(<TransitionNavigatorCard />);
+
+    const startButton = screen.getByRole('button', { name: /start planning my transition/i });
+    await userEvent.click(startButton);
+
+    expect(toastErrorMock).toHaveBeenCalledWith('Please log in to start planning');
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -6121,6 +6121,26 @@ export type Database = {
         Args: Record<PropertyKey, never> | { user_id: string }
         Returns: undefined
       }
+      start_transition_profile: {
+        Args: { p_departure_date?: string | null; p_is_enabled?: boolean | null }
+        Returns: {
+          id: string
+          user_id: string
+          departure_date: string
+          current_phase: string
+          transition_type: string
+          motivation: string | null
+          concerns: Json
+          is_enabled: boolean
+          auto_hide_after_departure: boolean
+          hide_days_after_departure: number
+          completion_percentage: number
+          last_milestone_reached: string | null
+          created_at: string
+          updated_at: string
+          archived_at: string | null
+        }
+      }
       store_pam_message: {
         Args:
           | Record<PropertyKey, never>

--- a/supabase/migrations/20250201000000-add-start-transition-profile-function.sql
+++ b/supabase/migrations/20250201000000-add-start-transition-profile-function.sql
@@ -1,0 +1,49 @@
+-- Migration: add start_transition_profile RPC helper
+-- Purpose: allow authenticated users to create or enable their transition profile without RLS violations
+-- Adds a SECURITY DEFINER function that wraps the transition_profiles upsert logic using auth.uid()
+
+create or replace function public.start_transition_profile(
+    p_departure_date date default null,
+    p_is_enabled boolean default true
+) returns public.transition_profiles
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_user_id uuid := auth.uid();
+    v_departure_date date := coalesce(p_departure_date, (now() at time zone 'utc')::date + 90);
+    v_profile public.transition_profiles;
+begin
+    if v_user_id is null then
+        raise exception 'start_transition_profile requires an authenticated user'
+            using errcode = 'P0001';
+    end if;
+
+    insert into public.transition_profiles as tp (
+        user_id,
+        departure_date,
+        is_enabled,
+        updated_at
+    )
+    values (
+        v_user_id,
+        v_departure_date,
+        coalesce(p_is_enabled, true),
+        now()
+    )
+    on conflict (user_id) do update
+        set departure_date = excluded.departure_date,
+            is_enabled = excluded.is_enabled,
+            updated_at = now()
+    returning tp.* into v_profile;
+
+    return v_profile;
+end;
+$$;
+
+revoke all on function public.start_transition_profile(date, boolean) from public;
+-- Ensure logged-in users can execute the helper while anonymous users cannot
+grant execute on function public.start_transition_profile(date, boolean) to authenticated;
+-- Allow backend service role to call the helper for automation tasks
+grant execute on function public.start_transition_profile(date, boolean) to service_role;


### PR DESCRIPTION
## Summary
- add a security-definer `start_transition_profile` function to handle transition profile upserts with proper grants
- switch the Transition Navigator CTA to call the RPC and surface detailed permission errors
- extend Supabase types and add focused unit tests for the new flow

## Testing
- npm run test -- TransitionNavigatorCard

------
https://chatgpt.com/codex/tasks/task_e_68ff30989a8c8323ac8456d63f997f69